### PR TITLE
Fix `.travis.yml`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   - make deps
 
 before_install:
-  - go get github.com/mhchia/sharding-p2p-poc
+  - go get github.com/ethresearch/sharding-p2p-poc
 
 script:
   - go test -v ./...


### PR DESCRIPTION
s/mhchia/ethresearch/g


cc @ChihChengLiang @hwwhww 
~~What do you think if we explicitly add a `cd $GOPATH/src/github.com/ethresearch/sharding-p2p-poc` after `go get github.com/ethresearch/sharding-p2p-poc` in the `before install` section in `.travis.yml`? like~~
```
before_install:
  - cd $GOPATH/src/github.com/ethresearch/sharding-p2p-poc
  - go get github.com/ethresearch/sharding-p2p-poc
```
~~I have this thought because with this `.travis.yml`, travis doesn't work well in my forked repo. The reason is it clones `mhchia/sharding-p2p-poc` and running `docker build .`, which builds the image with `mhchia/sharding-p2p-poc` instead of `ethresearch/sharding-p2p-poc` which is what we want.~~

CI passed(https://travis-ci.org/mhchia/sharding-p2p-poc/builds/408855753) so it seems possible that I misunderstood something.

Thank you!