### PR TITLE
Fix the wrong document URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > This is the poc of ethereum sharding p2p layer with pubsub in libp2p, based on the idea from the [slide](
 https://docs.google.com/presentation/d/11a0jibNz0fyUnsWt9fa2MmghHANdHAAABa0TV7EieHs/edit?usp=sharing).
 
-For more information, please check out the [document](https://github.com/ethresearch/sharding-p2p-poc/docs/tree/master/README.md).
+For more information, please check out the [document](https://github.com/ethresearch/sharding-p2p-poc/blob/master/docs/README.md).
 
 ## Install
 


### PR DESCRIPTION
### What was wrong?
The document URL in the readme is wrong


### How was it fixed?
Replace it with the correct one


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://scontent-tpe1-1.xx.fbcdn.net/v/t1.0-9/38243767_1017755658418835_1831868427225006080_n.jpg?_nc_cat=0&oh=7c4c4080539e2e00a31d02fd53ab2def&oe=5C1332DA)
