### PR TITLE
Try go-log and refactor error propagation

### DIFF
--- a/addpeer.go
+++ b/addpeer.go
@@ -91,7 +91,7 @@ func (p *AddPeerProtocol) AddPeer(ctx context.Context, peerAddr string) error {
 
 	peerid, targetAddr, err := parseAddr(peerAddr)
 	if err != nil {
-		logger.FinishWithErr(spanctx, err)
+		logger.FinishWithErr(spanctx, fmt.Errorf("Failed to parse peer address: %s, err: %v", peerAddr, err))
 		log.Println(err)
 		return err
 	}
@@ -104,7 +104,7 @@ func (p *AddPeerProtocol) AddPeer(ctx context.Context, peerAddr string) error {
 
 	s, err := p.node.NewStream(ctx, peerid, addPeerRequest)
 	if err != nil {
-		logger.FinishWithErr(spanctx, err)
+		logger.FinishWithErr(spanctx, fmt.Errorf("Failed to open a new stream with peer %v, err: %v", peerid, err))
 		log.Println(err)
 		return err
 	}

--- a/addpeer.go
+++ b/addpeer.go
@@ -19,22 +19,22 @@ type AddPeerProtocol struct {
 	node *Node // local host
 }
 
-func parseAddr(addrString string) (peerID peer.ID, protocolAddr ma.Multiaddr) {
+func parseAddr(addrString string) (peer.ID, ma.Multiaddr, error) {
 	// The following code extracts target's the peer ID from the
 	// given multiaddress
 	ipfsaddr, err := ma.NewMultiaddr(addrString) // ipfsaddr=/ip4/127.0.0.1/tcp/10000/ipfs/QmVmDaabYcS3pn23KaFjkdw6hkReUUma8sBKqSDHrPYPd2
 	if err != nil {
-		log.Fatalln(err)
+		return "", nil, err
 	}
 
 	pid, err := ipfsaddr.ValueForProtocol(ma.P_IPFS) // pid=QmVmDaabYcS3pn23KaFjkdw6hkReUUma8sBKqSDHrPYPd2
 	if err != nil {
-		log.Fatalln(err)
+		return "", nil, err
 	}
 
 	peerid, err := peer.IDB58Decode(pid) // peerid=<peer.ID VmDaab>
 	if err != nil {
-		log.Fatalln(err)
+		return "", nil, err
 	}
 
 	// Decapsulate the /ipfs/<peerID> part from the target
@@ -43,7 +43,7 @@ func parseAddr(addrString string) (peerID peer.ID, protocolAddr ma.Multiaddr) {
 		fmt.Sprintf("/ipfs/%s", peer.IDB58Encode(peerid)),
 	)
 	targetAddr := ipfsaddr.Decapsulate(targetPeerAddr)
-	return peerid, targetAddr
+	return peerid, targetAddr, nil
 }
 
 func NewAddPeerProtocol(node *Node) *AddPeerProtocol {
@@ -89,7 +89,13 @@ func (p *AddPeerProtocol) AddPeer(ctx context.Context, peerAddr string) error {
 	spanctx := logger.Start(ctx, "AddPeerProtocol.AddPeer")
 	defer logger.Finish(spanctx)
 
-	peerid, targetAddr := parseAddr(peerAddr)
+	peerid, targetAddr, err := parseAddr(peerAddr)
+	if err != nil {
+		logger.FinishWithErr(spanctx, err)
+		log.Println(err)
+		return err
+	}
+	log.Printf("%s: Sending addPeer to: %s....", p.node.Name(), peerid)
 	p.node.Peerstore().AddAddr(peerid, targetAddr, pstore.PermanentAddrTTL)
 	// create message data
 	req := &pbmsg.AddPeerRequest{

--- a/addpeer.go
+++ b/addpeer.go
@@ -98,6 +98,8 @@ func (p *AddPeerProtocol) AddPeer(ctx context.Context, peerAddr string) error {
 
 	s, err := p.node.NewStream(ctx, peerid, addPeerRequest)
 	if err != nil {
+		logger.FinishWithErr(spanctx, err)
+		log.Println(err)
 		return err
 	}
 

--- a/addpeer.go
+++ b/addpeer.go
@@ -95,7 +95,6 @@ func (p *AddPeerProtocol) AddPeer(ctx context.Context, peerAddr string) error {
 		log.Println(err)
 		return err
 	}
-	log.Printf("%s: Sending addPeer to: %s....", p.node.Name(), peerid)
 	p.node.Peerstore().AddAddr(peerid, targetAddr, pstore.PermanentAddrTTL)
 	// create message data
 	req := &pbmsg.AddPeerRequest{

--- a/addpeer.go
+++ b/addpeer.go
@@ -9,7 +9,6 @@ import (
 	peer "github.com/libp2p/go-libp2p-peer"
 	pstore "github.com/libp2p/go-libp2p-peerstore"
 	ma "github.com/multiformats/go-multiaddr"
-	opentracing "github.com/opentracing/opentracing-go"
 
 	pbmsg "github.com/ethresearch/sharding-p2p-poc/pb/message"
 )
@@ -87,8 +86,8 @@ func (p *AddPeerProtocol) onRequest(s inet.Stream) {
 
 func (p *AddPeerProtocol) AddPeer(ctx context.Context, peerAddr string) error {
 	// Add span for AddPeer of AddPeerProtocol
-	span, _ := opentracing.StartSpanFromContext(ctx, "AddPeerProtocol.AddPeer")
-	defer span.Finish()
+	spanctx := logger.Start(ctx, "AddPeerProtocol.AddPeer")
+	defer logger.Finish(spanctx)
 
 	peerid, targetAddr := parseAddr(peerAddr)
 	p.node.Peerstore().AddAddr(peerid, targetAddr, pstore.PermanentAddrTTL)

--- a/cli-example/iterate_all_rpc_call.sh
+++ b/cli-example/iterate_all_rpc_call.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# This script is expected to be executed in the root dir of the repo
+
+EXE_NAME="./sharding-p2p-poc"
+IP=127.0.0.1
+PORT=10000
+RPCPORT=13000
+
+# spinup_node {seed} {other_params}
+spinup_node() {
+    port=$((PORT+$1))
+    rpcport=$((RPCPORT+$1))
+    p=$@
+    params=${p[@]:1}
+    $EXE_NAME -seed=$1 -port=$port -rpcport=$rpcport $params &
+}
+
+cli_prompt() {
+    p=$@
+    seed=$1
+    params=${p[@]:1}
+    echo "$EXE_NAME -rpcport=$((RPCPORT+seed)) -client $params"
+}
+
+# add_peer {seed0} {seed1}
+add_peer() {
+    seed0=$1
+    seed1=$2
+    `cli_prompt $seed0` addpeer $IP $((PORT+seed1)) $seed1
+}
+
+# subscribe_shard {seed} {shard_id} {shard_id} ...
+subscribe_shard() {
+    p=$@
+    seed=$1
+    params=${p[@]:1}
+    `cli_prompt $seed` subshard $params
+}
+
+# unsubscribe_shard {seed} {shard_id} {shard_id} ...
+unsubscribe_shard() {
+    p=$@
+    seed=$1
+    params=${p[@]:1}
+    `cli_prompt $seed` unsubshard $params
+}
+
+# get_subscribe_shard {seed}
+get_subscribe_shard() {
+    p=$@
+    seed=$1
+    `cli_prompt $seed` getsubshard
+}
+
+# broadcast_collation {seed} {shard_id} {num_collation} {size} {period}
+broadcast_collation() {
+    p=$@
+    seed=$1
+    params=${p[@]:1}
+    `cli_prompt $seed` broadcastcollation $params
+}
+
+# stop_server {seed}
+stop_server() {
+    p=$@
+    seed=$1
+    `cli_prompt $seed` stop
+}
+
+make partial-gx-rw
+go build
+
+for i in `seq 0 1`;
+do
+    spinup_node $i
+done
+
+sleep 2
+
+# peer 0 add peer 1
+add_peer 0 1
+
+# peer 0 subscribe shard
+subscribe_shard 0 1 2 3 4 5
+
+# peer 1 subscribe shard
+subscribe_shard 1 2 3 4
+
+# get peer 0's subscribed shard
+get_subscribe_shard 0
+
+# peer 0 broadcast collations
+broadcast_collation 0 2 2 100 0
+
+# peer 1 broadcast collations
+broadcast_collation 1 1 1 100 0
+
+# peer 0 unsubscribe shard
+unsubscribe_shard 0 2 4
+
+get_subscribe_shard 0
+
+for i in `seq 0 1`;
+do
+    stop_server $i
+done
+
+make gx-uw

--- a/main.go
+++ b/main.go
@@ -28,14 +28,14 @@ import (
 
 type (
 	ShardIDType = int64
-	PBInt = int64
+	PBInt       = int64
 )
 
 const (
-	numShards ShardIDType = 100
-	defaultListenPort = 10000
-	defaultRPCPort    = 13000
-	defaultIP         = "127.0.0.1"
+	numShards         ShardIDType = 100
+	defaultListenPort             = 10000
+	defaultRPCPort                = 13000
+	defaultIP                     = "127.0.0.1"
 )
 
 func main() {
@@ -78,7 +78,6 @@ func main() {
 	}
 }
 
-
 func runClient(rpcAddr string, cliArgs []string) {
 	if len(cliArgs) <= 0 {
 		log.Fatalf("Client: wrong args")
@@ -118,7 +117,7 @@ func runServer(
 		// TODO: don't use eventNotifier if it is not available
 		eventNotifier = nil
 	}
-	var bootnodes  = []pstore.PeerInfo{}
+	var bootnodes = []pstore.PeerInfo{}
 	if bootnodesStr != "" {
 		bootnodes = convertPeers(strings.Split(bootnodesStr, ","))
 	}
@@ -157,7 +156,6 @@ func runServer(
 
 	runRPCServer(node, rpcAddr)
 }
-
 
 func doAddPeer(rpcArgs []string, rpcAddr string) {
 	if len(rpcArgs) != 3 {
@@ -233,7 +231,6 @@ func doBroadcastCollation(rpcArgs []string, rpcAddr string) {
 	)
 }
 
-
 func makeKey(seed int) (ic.PrivKey, peer.ID, error) {
 	// If the seed is zero, use real cryptographic randomness. Otherwise, use a
 	// deterministic randomness source to make generated keys stay the same
@@ -301,7 +298,7 @@ func makeNode(
 	}
 
 	// Make a host that listens on the given multiaddress
-	node := NewNode(ctx, routedHost, int(randseed), eventNotifier)
+	node := NewNode(ctx, routedHost, eventNotifier)
 
 	return node, nil
 }

--- a/node.go
+++ b/node.go
@@ -15,16 +15,14 @@ type Node struct {
 	*RequestProtocol // for peers to request data
 	*ShardManager
 
-	ctx    context.Context
-	number int
+	ctx context.Context
 }
 
 // NewNode creates a new node with its implemented protocols
-func NewNode(ctx context.Context, h host.Host, number int, eventNotifier EventNotifier) *Node {
+func NewNode(ctx context.Context, h host.Host, eventNotifier EventNotifier) *Node {
 	node := &Node{
-		Host:   h,
-		number: number,
-		ctx:    ctx,
+		Host: h,
+		ctx:  ctx,
 	}
 	node.AddPeerProtocol = NewAddPeerProtocol(node)
 	node.RequestProtocol = NewRequestProtocol(node)

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -225,10 +225,10 @@ func (s *server) StopServer(
 	req *pbrpc.RPCStopServerRequest) (*pbrpc.RPCPlainResponse, error) {
 	// Add span for StopServer
 	span := opentracing.StartSpan("RPCServer.StopServer", opentracing.ChildOf(s.parentSpan.Context()))
+	defer span.Finish()
 
 	log.Printf("rpcserver:StopServer: receive=%v", req)
 	time.Sleep(time.Millisecond * 500)
-	span.Finish()
 	log.Printf("Closing RPC server by rpc call...")
 	go func() {
 		time.Sleep(time.Second * 1)
@@ -243,6 +243,7 @@ func runRPCServer(n *Node, addr string) {
 	// Start a new trace
 	span := opentracing.StartSpan("RPCServer")
 	span.SetTag("Seed Number", n.number)
+	defer span.Finish()
 
 	lis, err := net.Listen("tcp", addr)
 	if err != nil {
@@ -262,5 +263,4 @@ func runRPCServer(n *Node, addr string) {
 
 	log.Printf("rpcserver: listening to %v", addr)
 	s.Serve(lis)
-	span.Finish()
 }

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -58,7 +58,7 @@ func (s *server) AddPeer(
 		targetPID.Pretty(),
 	)
 	if err != nil {
-		logger.FinishWithErr(spanctx, err)
+		logger.FinishWithErr(spanctx, fmt.Errorf("Failed to generate peer key/ID with seed: %v, err: %v", req.Seed, err))
 		log.Fatal(err)
 	}
 
@@ -243,7 +243,7 @@ func runRPCServer(n *Node, addr string) {
 
 	lis, err := net.Listen("tcp", addr)
 	if err != nil {
-		logger.FinishWithErr(ctx, err)
+		logger.FinishWithErr(ctx, fmt.Errorf("Failed to set up a service listening on %s, err: %v", addr, err))
 		log.Fatal(err)
 	}
 	s := grpc.NewServer()
@@ -260,7 +260,7 @@ func runRPCServer(n *Node, addr string) {
 
 	log.Printf("rpcserver: listening to %v", addr)
 	if err := s.Serve(lis); err != nil {
-		logger.FinishWithErr(ctx, err)
+		logger.FinishWithErr(ctx, fmt.Errorf("Failed to serve the RPC server, err: %v", err))
 		log.Fatal(err)
 	}
 }

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -59,7 +59,8 @@ func (s *server) AddPeer(
 	)
 	if err != nil {
 		logger.FinishWithErr(spanctx, fmt.Errorf("Failed to generate peer key/ID with seed: %v, err: %v", req.Seed, err))
-		log.Fatalf("Failed to generate peer key/ID with seed: %v, err: %v", req.Seed, err)
+		log.Printf("Failed to generate peer key/ID with seed: %v, err: %v", req.Seed, err)
+		return makePlainResponse(false, fmt.Sprintf("Failed to generate peer key/ID with seed: %v", req.Seed)), nil
 	}
 
 	var replyMsg string

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -259,5 +259,8 @@ func runRPCServer(n *Node, addr string) {
 	}()
 
 	log.Printf("rpcserver: listening to %v", addr)
-	s.Serve(lis)
+	if err := s.Serve(lis); err != nil {
+		logger.FinishWithErr(ctx, err)
+		log.Fatal(err)
+	}
 }

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -195,7 +195,7 @@ func (s *server) BroadcastCollation(
 		if err != nil {
 			failureMsg := fmt.Sprintf("broadcastcollation fails: %v", err)
 			log.Println(failureMsg)
-			logger.FinishWithErr(spanctx, fmt.Errorf("Failed to broadcast collation"))
+			logger.SetErr(spanctx, fmt.Errorf("Failed to broadcast collation"))
 			return makePlainResponse(false, failureMsg), err
 		}
 	}
@@ -255,7 +255,6 @@ func (s *server) StopServer(
 	defer logger.Finish(spanctx)
 
 	log.Printf("rpcserver:StopServer: receive=%v", req)
-	time.Sleep(time.Millisecond * 500)
 	log.Printf("Closing RPC server by rpc call...")
 	go func() {
 		time.Sleep(time.Second * 1)

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -270,7 +270,7 @@ func runRPCServer(n *Node, addr string) {
 	ctx := context.Background()
 	ctx = logger.Start(ctx, "RPCServer")
 	defer logger.Finish(ctx)
-	logger.SetTag(ctx, "Seed Number", n.number)
+	logger.SetTag(ctx, "Node ID %s", n.host.ID().Pretty())
 	serializedSpanCtx, err := logger.SerializeContext(ctx)
 	if err != nil {
 		logger.FinishWithErr(ctx, fmt.Errorf("Failed to serialize span context, err: %v", err))

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -58,6 +58,7 @@ func (s *server) AddPeer(
 		targetPID.Pretty(),
 	)
 	if err != nil {
+		logger.FinishWithErr(spanctx, err)
 		log.Fatal(err)
 	}
 
@@ -242,6 +243,7 @@ func runRPCServer(n *Node, addr string) {
 
 	lis, err := net.Listen("tcp", addr)
 	if err != nil {
+		logger.FinishWithErr(ctx, err)
 		log.Fatal(err)
 	}
 	s := grpc.NewServer()

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -230,7 +230,10 @@ func (s *server) StopServer(
 	time.Sleep(time.Millisecond * 500)
 	span.Finish()
 	log.Printf("Closing RPC server by rpc call...")
-	s.rpcServer.Stop()
+	go func() {
+		time.Sleep(time.Second * 1)
+		s.rpcServer.Stop()
+	}()
 
 	replyMsg := fmt.Sprintf("Closed RPC server")
 	return makePlainResponse(true, replyMsg), nil

--- a/shardmanager.go
+++ b/shardmanager.go
@@ -101,7 +101,7 @@ func (n *ShardManager) connectShardNodes(ctx context.Context, shardID ShardIDTyp
 
 			defer wg.Done()
 			if err := n.host.Connect(ctx, p); err != nil {
-				logger.SetErr(childSpanctx, fmt.Errorf("Failed to connect peer %v in shard %v", p.ID, shardID))
+				logger.SetErr(childSpanctx, fmt.Errorf("Failed to connect peer %v in shard %v, err: %v", p.ID, shardID, err))
 				log.Printf(
 					"Failed to connect peer %v in shard %v: %s",
 					p.ID,
@@ -262,7 +262,7 @@ func (n *ShardManager) PublishListeningShards(ctx context.Context) {
 	selfListeningShards := n.shardPrefTable.GetPeerListeningShard(n.host.ID())
 	bytes := selfListeningShards.toBytes()
 	if err := n.pubsubService.Publish(listeningShardTopic, bytes); err != nil {
-		logger.SetErr(spanctx, fmt.Errorf("Failed to publish listening shards"))
+		logger.SetErr(spanctx, fmt.Errorf("Failed to publish listening shards, err: %v", err))
 	}
 }
 
@@ -346,7 +346,7 @@ func (n *ShardManager) broadcastCollation(
 	}
 	err := n.broadcastCollationMessage(data)
 	if err != nil {
-		logger.SetErr(spanctx, fmt.Errorf("Failed to broadcast collation message"))
+		logger.SetErr(spanctx, fmt.Errorf("Failed to broadcast collation message, err: %v", err))
 	}
 	return err
 }

--- a/shardmanager.go
+++ b/shardmanager.go
@@ -97,6 +97,7 @@ func (n *ShardManager) connectShardNodes(ctx context.Context, shardID ShardIDTyp
 		go func(p pstore.PeerInfo) {
 			defer wg.Done()
 			if err := n.host.Connect(ctx, p); err != nil {
+				logger.FinishWithErr(spanctx, err)
 				log.Printf(
 					"Failed to connect peer %v in shard %v: %s",
 					p.ID,

--- a/shardmanager.go
+++ b/shardmanager.go
@@ -377,12 +377,12 @@ func (n *ShardManager) broadcastCollationMessage(collation *pbmsg.Collation) err
 	collationsTopic := getCollationsTopic(collation.ShardID)
 	bytes, err := proto.Marshal(collation)
 	if err != nil {
-		log.Fatal(err)
+		log.Println(err)
 		return err
 	}
 	err = n.pubsubService.Publish(collationsTopic, bytes)
 	if err != nil {
-		log.Fatal(err)
+		log.Println(err)
 		return err
 	}
 	return nil


### PR DESCRIPTION
### What was wrong?
[go-log](https://github.com/ipfs/go-log) is ipfs's library for logging which also supports APIs similar to opentracing's. The APIs are mainly wrappers over the original opentracing APIs(though not all of them) with some extra functionalities, see [doc](https://godoc.org/github.com/ipfs/go-log#example-EventLogger).

Differences between go-log and opentracing:
1. go-log generates spans from context object(e.g., `logger.Start(ctx, "span name")`) while in opentracing it's optional(opentracing supports `opentracing.StartSpan("span name", childOf(parentSpan)`, `opentracing.StartSpanFromConext(ctx, "span name", childOf(parentSpan))`)
    - This makes it easier for go-log to pass along parent span.
    - Though opentracing also supports injecting/extracting span into/from context object(e.g. `opentracing.ContextWithSpan` and `opentracing.SpanFromContext`).
2. go-log does not support `span.setBaggageItem` which helps propagating shared information(the information shared by span and it's ancestor) to all descendant spans.
    - Though these information could be passed along via context object in go-log.
3. go-log does not support `Inject` and `Extract` which helps propagating shared information across processes(i.e., interprocess tracing).
    - Though these information could also be passed between sender and receiver as long as they are on the same page which also means that the tracing framework used can not be abstracted away on either side.

### How was it fixed?
- [x] Replace opentracing API with go-log API
- [x] Log error(if any) in span
- [x] Refactor error handling
    - [x] Have some functions return error
    - [x] Catch error when needed and log the error message
    - [x] Add some human readable message to error logging
    - [x] Replace `Fatal*` with `Printf*`

#### Cute Animal Picture

![](https://upload.wikimedia.org/wikipedia/commons/thumb/c/cf/Scottish_Fold_lila.jpg/1596px-Scottish_Fold_lila.jpg)