### PR TITLE
Add test for `requestCollation` with `eventNotifier`, and remove one redundant step of `AddPeer`

### DIFF
--- a/addpeer.go
+++ b/addpeer.go
@@ -66,7 +66,7 @@ func (p *AddPeerProtocol) onRequest(s inet.Stream) {
 
 	log.Printf(
 		"%s: Received addPeer request from %s. Message: %s",
-		p.node.Name(),
+		p.node.ID(),
 		s.Conn().RemotePeer(),
 		data.Message,
 	)
@@ -94,7 +94,7 @@ func (p *AddPeerProtocol) AddPeer(ctx context.Context, peerAddr string) error {
 	p.node.Peerstore().AddAddr(peerid, targetAddr, pstore.PermanentAddrTTL)
 	// create message data
 	req := &pbmsg.AddPeerRequest{
-		Message: fmt.Sprintf("AddPeer from %s", p.node.Name()),
+		Message: fmt.Sprintf("AddPeer from %s", p.node.ID()),
 	}
 
 	s, err := p.node.NewStream(ctx, peerid, addPeerRequest)

--- a/addpeer.go
+++ b/addpeer.go
@@ -14,11 +14,8 @@ import (
 	pbmsg "github.com/ethresearch/sharding-p2p-poc/pb/message"
 )
 
-// pattern: /protocol-name/request-or-response-message/version
 const addPeerRequest = "/addPeer/request/0.0.1"
-const addPeerResponse = "/addPeer/response/0.0.1"
 
-// AddPeerProtocol type
 type AddPeerProtocol struct {
 	node *Node // local host
 }
@@ -55,16 +52,15 @@ func NewAddPeerProtocol(node *Node) *AddPeerProtocol {
 		node: node,
 	}
 	node.SetStreamHandler(addPeerRequest, p.onRequest)
-	node.SetStreamHandler(addPeerResponse, p.onResponse)
 	return p
 }
 
 // remote peer requests handler
 func (p *AddPeerProtocol) onRequest(s inet.Stream) {
+	defer inet.FullClose(s)
 	// get request data
 	data := &pbmsg.AddPeerRequest{}
-	if !readProtoMessage(data, s) {
-		s.Close()
+	if err := readProtoMessage(data, s); err != nil {
 		return
 	}
 
@@ -75,13 +71,8 @@ func (p *AddPeerProtocol) onRequest(s inet.Stream) {
 		data.Message,
 	)
 
-	// generate response message
-	log.Printf(
-		"%s: Sending addPeer response to %s",
-		p.node.Name(),
-		s.Conn().RemotePeer(),
-	)
-
+	// TODO: add logics for handshake and initialization, e.g. asking for shard peers
+	//		 if nothing is wrong, accept this peer.
 	resp := &pbmsg.AddPeerResponse{
 		Response: &pbmsg.Response{Status: pbmsg.Response_SUCCESS},
 	}
@@ -91,39 +82,15 @@ func (p *AddPeerProtocol) onRequest(s inet.Stream) {
 		s.Conn().RemoteMultiaddr(),
 		pstore.PermanentAddrTTL,
 	)
-
-	sResponse, err := p.node.NewStream(p.node.ctx, s.Conn().RemotePeer(), addPeerResponse)
-	if err != nil {
-		log.Println(err)
-		return
-	}
-	if !sendProtoMessage(resp, sResponse) {
-		sResponse.Close()
-	}
+	sendProtoMessage(resp, s)
 }
 
-// remote addPeer response handler
-func (p *AddPeerProtocol) onResponse(s inet.Stream) {
-	data := &pbmsg.AddPeerResponse{}
-	if !readProtoMessage(data, s) {
-		s.Close()
-		return
-	}
-	log.Printf(
-		"%s: Received addPeer response from %s, result=%v",
-		p.node.Name(),
-		s.Conn().RemotePeer(),
-		data.Response.Status,
-	)
-}
-
-func (p *AddPeerProtocol) AddPeer(ctx context.Context, peerAddr string) bool {
+func (p *AddPeerProtocol) AddPeer(ctx context.Context, peerAddr string) error {
 	// Add span for AddPeer of AddPeerProtocol
 	span, _ := opentracing.StartSpanFromContext(ctx, "AddPeerProtocol.AddPeer")
 	defer span.Finish()
 
 	peerid, targetAddr := parseAddr(peerAddr)
-	log.Printf("%s: Sending addPeer to: %s....", p.node.Name(), peerid)
 	p.node.Peerstore().AddAddr(peerid, targetAddr, pstore.PermanentAddrTTL)
 	// create message data
 	req := &pbmsg.AddPeerRequest{
@@ -132,8 +99,7 @@ func (p *AddPeerProtocol) AddPeer(ctx context.Context, peerAddr string) bool {
 
 	s, err := p.node.NewStream(ctx, peerid, addPeerRequest)
 	if err != nil {
-		log.Println(err)
-		return false
+		return err
 	}
 
 	return sendProtoMessage(req, s)

--- a/main_test.go
+++ b/main_test.go
@@ -188,7 +188,7 @@ func TestRequestCollation(t *testing.T) {
 	}
 	if collation != nil {
 		t.Errorf(
-			"collation should not be returned since we didn't set an eventNotifier in nodes[1]"
+			"collation should not be returned since we didn't set an eventNotifier in nodes[1]",
 		)
 	}
 }

--- a/node.go
+++ b/node.go
@@ -33,11 +33,6 @@ func NewNode(ctx context.Context, h host.Host, number int, eventNotifier EventNo
 	return node
 }
 
-func (n *Node) Name() string {
-	id := n.ID().Pretty()
-	return fmt.Sprintf("<Node %d %s>", n.number, id[2:8])
-}
-
 func (n *Node) GetFullAddr() string {
 	hostAddr, _ := ma.NewMultiaddr(fmt.Sprintf("/ipfs/%s", n.ID().Pretty()))
 

--- a/requests.go
+++ b/requests.go
@@ -93,6 +93,7 @@ func (p *RequestProtocol) requestShardPeer(
 		peerID,
 		shardPeerRequestProtocol,
 	)
+	defer s.Close()
 	if err != nil {
 		return nil, fmt.Errorf("failed to open new stream")
 	}
@@ -104,7 +105,6 @@ func (p *RequestProtocol) requestShardPeer(
 	}
 	res := &pbmsg.ShardPeerResponse{}
 	if err := readProtoMessage(res, s); err != nil {
-		s.Close()
 		return nil, fmt.Errorf("failed to read response proto")
 	}
 	shardPeers := make(map[ShardIDType][]peer.ID)
@@ -169,6 +169,7 @@ func (p *RequestProtocol) requestCollation(
 		peerID,
 		collationRequestProtocol,
 	)
+	defer s.Close()
 	if err != nil {
 		return nil, fmt.Errorf("failed to open new stream %v", err)
 	}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -65,7 +65,8 @@ func (s *server) AddPeer(
 	spanctx := opentracing.ContextWithSpan(ctx, span)
 
 	var replyMsg string
-	success := s.node.AddPeer(spanctx, mAddr)
+	err = s.node.AddPeer(spanctx, mAddr)
+	success := (err == nil)
 	if success {
 		replyMsg = fmt.Sprintf("Added Peer %v:%v, pid=%v!", req.Ip, req.Port, targetPID)
 		// Tag the span with peer info

--- a/shardmanager.go
+++ b/shardmanager.go
@@ -366,6 +366,7 @@ func (n *ShardManager) getCollation(
 	period int,
 	collationHash string) (*pbmsg.Collation, error) {
 
+	// get collations from remote clients only when `n.eventNotifier` is set
 	if n.eventNotifier != nil {
 		collation, err := n.eventNotifier.GetCollation(shardID, period, collationHash)
 		if err != nil {
@@ -373,7 +374,7 @@ func (n *ShardManager) getCollation(
 		}
 		return collation, nil
 	}
-	// FIXME: currently we just return a fake one if we fail to get content from the `eventNotifier`
+	// FIXME: else we just return a fake one if we fail to get content from the `eventNotifier`
 	return &pbmsg.Collation{
 		ShardID: PBInt(shardID),
 		Period:  PBInt(period),

--- a/shardmanager.go
+++ b/shardmanager.go
@@ -365,7 +365,6 @@ func (n *ShardManager) getCollation(
 	shardID ShardIDType,
 	period int,
 	collationHash string) (*pbmsg.Collation, error) {
-
 	// get collations from remote clients only when `n.eventNotifier` is set
 	if n.eventNotifier != nil {
 		collation, err := n.eventNotifier.GetCollation(shardID, period, collationHash)
@@ -374,10 +373,5 @@ func (n *ShardManager) getCollation(
 		}
 		return collation, nil
 	}
-	// FIXME: else we just return a fake one if we fail to get content from the `eventNotifier`
-	return &pbmsg.Collation{
-		ShardID: PBInt(shardID),
-		Period:  PBInt(period),
-		Blobs:   []byte{},
-	}, nil
+	return nil, nil
 }


### PR DESCRIPTION
### What was wrong?
- Lack of test for `requestCollation` with `eventNotifier`
- One redundant step of `AddPeer`: `onResponse`

### How was it fixed?
- Added the test for `requestCollation` with `eventNotifier`
- Remove the redundant step of `onResponse`
- Refactor `main_test.go` a little bit 


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://scontent.ftpe7-4.fna.fbcdn.net/v/t1.0-9/40530044_1052559164938484_4615368845509525504_n.jpg?_nc_fx=ftpe7-2&_nc_cat=0&oh=54173a3f7d814f0a0cb9f470262ea55f&oe=5C259FC8)
