### PR TITLE
Replace builtin log with go log

### DIFF
--- a/bootstrap.go
+++ b/bootstrap.go
@@ -18,7 +18,7 @@ func convertPeers(peers []string) []pstore.PeerInfo {
 		p, err := pstore.InfoFromP2pAddr(maddr)
 		if err != nil {
 			// TODO: should just skip?
-			logger.Panicf("Failed to convert address %v to peer info, err: %v", maddr, err)
+			logger.Fatalf("Failed to convert address %v to peer info, err: %v", maddr, err)
 		}
 		pinfos[i] = *p
 	}

--- a/bootstrap.go
+++ b/bootstrap.go
@@ -11,18 +11,17 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 )
 
-func convertPeers(peers []string) []pstore.PeerInfo {
+func convertPeers(peers []string) ([]pstore.PeerInfo, error) {
 	pinfos := make([]pstore.PeerInfo, len(peers))
 	for i, peer := range peers {
 		maddr := ma.StringCast(peer)
 		p, err := pstore.InfoFromP2pAddr(maddr)
 		if err != nil {
-			// TODO: should just skip?
-			logger.Fatalf("Failed to convert address %v to peer info, err: %v", maddr, err)
+			return nil, err
 		}
 		pinfos[i] = *p
 	}
-	return pinfos
+	return pinfos, nil
 }
 
 // This code is borrowed from the go-ipfs bootstrap process

--- a/bootstrap.go
+++ b/bootstrap.go
@@ -47,7 +47,6 @@ func bootstrapConnect(ctx context.Context, ph host.Host, peers []pstore.PeerInfo
 
 			ph.Peerstore().AddAddrs(p.ID, p.Addrs, pstore.PermanentAddrTTL)
 			if err := ph.Connect(ctx, p); err != nil {
-				logger.Error(ctx, "bootstrapDialFailed", p.ID)
 				logger.Errorf("Failed to bootstrap with %v: %s", p.ID, err)
 				errs <- err
 				return

--- a/eventrpc.go
+++ b/eventrpc.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
 
 	pbevent "github.com/ethresearch/sharding-p2p-poc/pb/event"
 	pbmsg "github.com/ethresearch/sharding-p2p-poc/pb/message"
@@ -27,7 +26,7 @@ type rpcEventNotifier struct {
 func NewRpcEventNotifier(ctx context.Context, rpcAddr string) (*rpcEventNotifier, error) {
 	conn, err := grpc.Dial(rpcAddr, grpc.WithInsecure())
 	if err != nil {
-		log.Printf("failed to connect to the rpc server: %v", err)
+		logger.Errorf("failed to connect to the rpc server: %v", err)
 		return nil, err
 	}
 	client := pbevent.NewEventClient(conn)

--- a/main.go
+++ b/main.go
@@ -123,7 +123,10 @@ func runServer(
 	}
 	var bootnodes = []pstore.PeerInfo{}
 	if bootnodesStr != "" {
-		bootnodes = convertPeers(strings.Split(bootnodesStr, ","))
+		bootnodes, err = convertPeers(strings.Split(bootnodesStr, ","))
+		if err != nil {
+			logger.Errorf("Failed to convert bootnode address: %v, to peer info format, err: %v", bootnodesStr, err)
+		}
 	}
 
 	node, err := makeNode(

--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"log"
 	mrand "math/rand"
 	"strconv"
 	"strings"
@@ -12,6 +11,7 @@ import (
 	// gologging "gx/ipfs/QmQvJiADDe7JR4m968MwXobTCCzUqQkP87aRHe29MEBGHV/go-logging"
 	ds "github.com/ipfs/go-datastore"
 	dsync "github.com/ipfs/go-datastore/sync"
+	logging "github.com/ipfs/go-log"
 	libp2p "github.com/libp2p/go-libp2p"
 	crypto "github.com/libp2p/go-libp2p-crypto"
 	ic "github.com/libp2p/go-libp2p-crypto"
@@ -25,6 +25,8 @@ import (
 
 	kaddht "github.com/libp2p/go-libp2p-kad-dht"
 )
+
+var logger = logging.Logger("sharding-p2p")
 
 type (
 	ShardIDType = int64
@@ -80,7 +82,7 @@ func main() {
 
 func runClient(rpcAddr string, cliArgs []string) {
 	if len(cliArgs) <= 0 {
-		log.Fatalf("Client: wrong args")
+		logger.Fatal("Client: Invalid args")
 		return
 	}
 	rpcCmd := cliArgs[0]
@@ -99,7 +101,7 @@ func runClient(rpcAddr string, cliArgs []string) {
 	case "stop":
 		callRPCStopServer(rpcAddr)
 	default:
-		log.Fatalf("Client: wrong cmd '%v'", rpcCmd)
+		logger.Fatalf("Client: Invalid cmd '%v'", rpcCmd)
 	}
 }
 
@@ -132,7 +134,7 @@ func runServer(
 		bootnodes,
 	)
 	if err != nil {
-		log.Fatal(err)
+		logger.Panicf("Failed to make node, err: %v", err)
 	}
 
 	// Set up Opentracing and Jaeger tracer
@@ -159,7 +161,7 @@ func runServer(
 
 func doAddPeer(rpcArgs []string, rpcAddr string) {
 	if len(rpcArgs) != 3 {
-		log.Fatalf("Client: usage: addpeer ip port seed")
+		logger.Fatal("Client: usage: addpeer ip port seed")
 	}
 	targetIP := rpcArgs[0]
 	targetPort, err := strconv.Atoi(rpcArgs[1])
@@ -172,7 +174,7 @@ func doAddPeer(rpcArgs []string, rpcAddr string) {
 
 func doSubShard(rpcArgs []string, rpcAddr string) {
 	if len(rpcArgs) == 0 {
-		log.Fatalf("Client: usage: subshard shard0 shard1 ...")
+		logger.Fatal("Client: usage: subshard shard0 shard1 ...")
 	}
 	shardIDs := []ShardIDType{}
 	for _, shardIDString := range rpcArgs {
@@ -187,7 +189,7 @@ func doSubShard(rpcArgs []string, rpcAddr string) {
 
 func doUnsubShard(rpcArgs []string, rpcAddr string) {
 	if len(rpcArgs) == 0 {
-		log.Fatalf("Client: usage: unsubshard shard0 shard1 ...")
+		logger.Fatal("Client: usage: unsubshard shard0 shard1 ...")
 	}
 	shardIDs := []ShardIDType{}
 	for _, shardIDString := range rpcArgs {
@@ -202,25 +204,25 @@ func doUnsubShard(rpcArgs []string, rpcAddr string) {
 
 func doBroadcastCollation(rpcArgs []string, rpcAddr string) {
 	if len(rpcArgs) != 4 {
-		log.Fatalf(
+		logger.Fatal(
 			"Client: usage: broadcastcollation shardID, numCollations, collationSize, timeInMs",
 		)
 	}
 	shardID, err := strconv.ParseInt(rpcArgs[0], 10, 64)
 	if err != nil {
-		log.Fatalf("wrong shard: %v", rpcArgs)
+		logger.Fatalf("Invalid shard: %v", rpcArgs[0])
 	}
 	numCollations, err := strconv.Atoi(rpcArgs[1])
 	if err != nil {
-		log.Fatalf("wrong numCollations: %v", rpcArgs)
+		logger.Fatalf("Invalid numCollations: %v", rpcArgs[1])
 	}
 	collationSize, err := strconv.Atoi(rpcArgs[2])
 	if err != nil {
-		log.Fatalf("wrong collationSize: %v", rpcArgs)
+		logger.Fatalf("Invalid collationSize: %v", rpcArgs[2])
 	}
 	timeInMs, err := strconv.Atoi(rpcArgs[3])
 	if err != nil {
-		log.Fatalf("wrong timeInMs: %v", rpcArgs)
+		logger.Fatalf("Invalid timeInMs: %v", rpcArgs[3])
 	}
 	callRPCBroadcastCollation(
 		rpcAddr,

--- a/main.go
+++ b/main.go
@@ -136,7 +136,7 @@ func runServer(
 		bootnodes,
 	)
 	if err != nil {
-		logger.Panicf("Failed to make node, err: %v", err)
+		logger.Fatalf("Failed to make node, err: %v", err)
 	}
 
 	// Set up Opentracing and Jaeger tracer
@@ -282,7 +282,7 @@ func makeNode(
 		libp2p.ListenAddrStrings(listenAddrString),
 	)
 	if err != nil {
-		logger.Panicf("Failed to create new libp2p host, err: %v", err)
+		return nil, err
 	}
 
 	// Construct a datastore (needed by the DHT). This is just a simple, in-memory thread-safe datastore.

--- a/main.go
+++ b/main.go
@@ -151,7 +151,7 @@ func runServer(
 	tracer, closer, err := cfg.New(tracerName, jaegerconfig.Logger(jaeger.StdLogger))
 	defer closer.Close()
 	if err != nil {
-		panic(fmt.Sprintf("ERROR: cannot init Jaeger: %v\n", err))
+		logger.Debugf("Failed to create tracer, err: %v", err)
 	}
 	opentracing.SetGlobalTracer(tracer)
 	// End of tracer setup
@@ -165,9 +165,12 @@ func doAddPeer(rpcArgs []string, rpcAddr string) {
 	}
 	targetIP := rpcArgs[0]
 	targetPort, err := strconv.Atoi(rpcArgs[1])
+	if err != nil {
+		logger.Fatalf("Failed to convert string '%v' to integer, err: %v", rpcArgs[1])
+	}
 	targetSeed, err := strconv.Atoi(rpcArgs[2])
 	if err != nil {
-		panic(err)
+		logger.Fatalf("Failed to convert string '%v' to integer, err: %v", rpcArgs[2])
 	}
 	callRPCAddPeer(rpcAddr, targetIP, targetPort, targetSeed)
 }
@@ -180,7 +183,7 @@ func doSubShard(rpcArgs []string, rpcAddr string) {
 	for _, shardIDString := range rpcArgs {
 		shardID, err := strconv.ParseInt(shardIDString, 10, 64)
 		if err != nil {
-			panic(err)
+			logger.Fatalf("Failed to convert string '%v' to integer, err: %v", shardIDString, err)
 		}
 		shardIDs = append(shardIDs, shardID)
 	}
@@ -195,7 +198,7 @@ func doUnsubShard(rpcArgs []string, rpcAddr string) {
 	for _, shardIDString := range rpcArgs {
 		shardID, err := strconv.ParseInt(shardIDString, 10, 64)
 		if err != nil {
-			panic(err)
+			logger.Fatalf("Failed to convert string '%v' to integer, err: %v", shardIDString, err)
 		}
 		shardIDs = append(shardIDs, shardID)
 	}
@@ -277,7 +280,7 @@ func makeNode(
 		libp2p.ListenAddrStrings(listenAddrString),
 	)
 	if err != nil {
-		panic(err)
+		logger.Panicf("Failed to create new libp2p host, err: %v", err)
 	}
 
 	// Construct a datastore (needed by the DHT). This is just a simple, in-memory thread-safe datastore.

--- a/main.go
+++ b/main.go
@@ -67,11 +67,13 @@ func main() {
 	)
 	doBootstrapping := flag.Bool("bootstrap", false, "whether to do bootstrapping or not")
 	bootnodesStr := flag.String("bootnodes", "", "multiaddresses of the bootnodes")
+	logLevel := flag.String("loglevel", "INFO", "setting log level, e.g., DEBUG, WARNING, INFO, ERROR, CRITICAL")
 	isClient := flag.Bool("client", false, "is RPC client or server")
 	flag.Parse()
 
 	rpcAddr := fmt.Sprintf("%v:%v", *rpcIP, *rpcPort)
 	notifierAddr := fmt.Sprintf("%v:%v", *rpcIP, *notifierPort)
+	logging.SetLogLevel("sharding-p2p", *logLevel)
 
 	if *isClient {
 		runClient(rpcAddr, flag.Args())

--- a/main_test.go
+++ b/main_test.go
@@ -134,13 +134,16 @@ func TestWithIPFSNodesRouting(t *testing.T) {
 	defer cancel()
 
 	// golog.SetAllLoggers(gologging.DEBUG) // Change to DEBUG for extra info
-	ipfsPeers := convertPeers([]string{
+	ipfsPeers, err := convertPeers([]string{
 		"/ip4/127.0.0.1/tcp/4001/ipfs/QmXa1ncfGc9RQotUAyN3Gb4ar7WXZ4DEb2wPZsSybkK1sf",
 		"/ip4/104.131.131.82/tcp/4001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",
 		"/ip4/104.236.179.241/tcp/4001/ipfs/QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM",
 		"/ip4/128.199.219.111/tcp/4001/ipfs/QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu",
 		"/ip4/178.62.158.247/tcp/4001/ipfs/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd",
 	})
+	if err != nil {
+		t.Error("Failed to convert ipfs peers info")
+	}
 	ipfsPeer0 := ipfsPeers[0]
 	ipfsPeer1 := ipfsPeers[1]
 

--- a/requests.go
+++ b/requests.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"log"
 
 	pbmsg "github.com/ethresearch/sharding-p2p-poc/pb/message"
 	"github.com/golang/protobuf/proto"
@@ -79,7 +78,7 @@ func (p *RequestProtocol) onShardPeerRequest(s inet.Stream) {
 		ShardPeers: shardPeers,
 	}
 	if err := sendProtoMessage(res, s); err != nil {
-		log.Printf("onShardPeerRequest: failed to send proto message %v, reason=%v", res, err)
+		logger.Errorf("onShardPeerRequest: failed to send proto message '%v', err: %v", res, err)
 		return
 	}
 }
@@ -156,8 +155,8 @@ func (p *RequestProtocol) onCollationRequest(s inet.Stream) {
 		}
 	}
 	if err := sendProtoMessage(collationResp, s); err != nil {
-		log.Printf(
-			"onCollationRequest: failed to send proto message %v, reason=%v",
+		logger.Errorf(
+			"onCollationRequest: failed to send proto message '%v', err: %v",
 			collationResp,
 			err,
 		)

--- a/rpcclient.go
+++ b/rpcclient.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"log"
 
 	pbrpc "github.com/ethresearch/sharding-p2p-poc/pb/rpc"
 	"google.golang.org/grpc"
@@ -12,7 +10,7 @@ import (
 func callRPCAddPeer(rpcAddr string, ipAddr string, port int, seed int) {
 	conn, err := grpc.Dial(rpcAddr, grpc.WithInsecure())
 	if err != nil {
-		log.Fatalf("did not connect: %v", err)
+		logger.Fatalf("Failed to connect to RPC server at %v, err: %v", rpcAddr, err)
 	}
 	defer conn.Close()
 	client := pbrpc.NewPocClient(conn)
@@ -21,64 +19,64 @@ func callRPCAddPeer(rpcAddr string, ipAddr string, port int, seed int) {
 		Port: PBInt(port),
 		Seed: PBInt(seed),
 	}
-	log.Printf("rpcclient:AddPeer: sending=%v", addPeerReq)
+	logger.Debugf("rpcclient:AddPeer: sending=%v", addPeerReq)
 	res, err := client.AddPeer(context.Background(), addPeerReq)
 	if err != nil {
-		log.Fatal(err)
+		logger.Fatalf("Failed to add peer at %v:%v, err: %v", ipAddr, port, err)
 	}
-	log.Printf("rpcclient:AddPeer: result=%v", res)
+	logger.Debugf("rpcclient:AddPeer: result=%v", res)
 }
 
 func callRPCSubscribeShard(rpcAddr string, shardIDs []ShardIDType) {
 	conn, err := grpc.Dial(rpcAddr, grpc.WithInsecure())
 	if err != nil {
-		log.Fatalf("did not connect: %v", err)
+		logger.Fatalf("Failed to connect to RPC server at %v, err: %v", rpcAddr, err)
 	}
 	defer conn.Close()
 	client := pbrpc.NewPocClient(conn)
 	subscribeShardReq := &pbrpc.RPCSubscribeShardRequest{
 		ShardIDs: shardIDs,
 	}
-	log.Printf("rpcclient:ShardReq: sending=%v", subscribeShardReq)
+	logger.Debugf("rpcclient:ShardReq: sending=%v", subscribeShardReq)
 	res, err := client.SubscribeShard(context.Background(), subscribeShardReq)
 	if err != nil {
-		log.Fatal(err)
+		logger.Fatalf("Failed to subscribe to shards %v, err: %v", shardIDs, err)
 	}
-	log.Printf("rpcclient:ShardReq: result=%v", res)
+	logger.Debugf("rpcclient:ShardReq: result=%v", res)
 }
 
 func callRPCUnsubscribeShard(rpcAddr string, shardIDs []ShardIDType) {
 	conn, err := grpc.Dial(rpcAddr, grpc.WithInsecure())
 	if err != nil {
-		log.Fatalf("did not connect: %v", err)
+		logger.Fatalf("Failed to connect to RPC server at %v, err: %v", rpcAddr, err)
 	}
 	defer conn.Close()
 	client := pbrpc.NewPocClient(conn)
 	unsubscribeShardReq := &pbrpc.RPCUnsubscribeShardRequest{
 		ShardIDs: shardIDs,
 	}
-	log.Printf("rpcclient:UnsubscribeShardReq: sending=%v", unsubscribeShardReq)
+	logger.Debugf("rpcclient:UnsubscribeShardReq: sending=%v", unsubscribeShardReq)
 	res, err := client.UnsubscribeShard(context.Background(), unsubscribeShardReq)
 	if err != nil {
-		log.Fatal(err)
+		logger.Fatalf("Failed to unsubscribe shards %v, err: %v", shardIDs, err)
 	}
-	log.Printf("rpcclient:UnsubscribeShardReq: result=%v", res)
+	logger.Debugf("rpcclient:UnsubscribeShardReq: result=%v", res)
 }
 
 func callRPCGetSubscribedShard(rpcAddr string) {
 	conn, err := grpc.Dial(rpcAddr, grpc.WithInsecure())
 	if err != nil {
-		log.Fatalf("did not connect: %v", err)
+		logger.Fatalf("Failed to connect to RPC server at %v, err: %v", rpcAddr, err)
 	}
 	defer conn.Close()
 	client := pbrpc.NewPocClient(conn)
 	getSubscribedShardReq := &pbrpc.RPCGetSubscribedShardRequest{}
-	log.Printf("rpcclient:GetSubscribedShard: sending=%v", getSubscribedShardReq)
+	logger.Debugf("rpcclient:GetSubscribedShard: sending=%v", getSubscribedShardReq)
 	res, err := client.GetSubscribedShard(context.Background(), getSubscribedShardReq)
 	if err != nil {
-		log.Fatal(err)
+		logger.Fatalf("Failed to get subscribed shards, err: %v", err)
 	}
-	log.Printf("rpcclient:GetSubscribedShard: result=%v", res.ShardIDs)
+	logger.Debugf("rpcclient:GetSubscribedShard: result=%v", res.ShardIDs)
 }
 
 func callRPCBroadcastCollation(
@@ -89,7 +87,7 @@ func callRPCBroadcastCollation(
 	period int) {
 	conn, err := grpc.Dial(rpcAddr, grpc.WithInsecure())
 	if err != nil {
-		log.Fatalf("did not connect: %v", err)
+		logger.Fatalf("Failed to connect to RPC server at %v, err: %v", rpcAddr, err)
 	}
 	defer conn.Close()
 	client := pbrpc.NewPocClient(conn)
@@ -99,26 +97,26 @@ func callRPCBroadcastCollation(
 		Size:    PBInt(collationSize),
 		Period:  PBInt(period),
 	}
-	log.Printf("rpcclient:BroadcastCollation: sending=%v", broadcastCollationReq)
+	logger.Debugf("rpcclient:BroadcastCollation: sending=%v", broadcastCollationReq)
 	res, err := client.BroadcastCollation(context.Background(), broadcastCollationReq)
 	if err != nil {
-		log.Fatal(err)
+		logger.Fatalf("Failed to broadcast %v collations of size %v in period %v in shard %v, err: %v", numCollations, collationSize, period, shardID, err)
 	}
-	log.Printf("rpcclient:BroadcastCollation: result=%v", res)
+	logger.Debugf("rpcclient:BroadcastCollation: result=%v", res)
 }
 
 func callRPCStopServer(rpcAddr string) {
 	conn, err := grpc.Dial(rpcAddr, grpc.WithInsecure())
 	if err != nil {
-		log.Fatalf("did not connect: %v", err)
+		logger.Fatalf("Failed to connect to RPC server at %v, err: %v", rpcAddr, err)
 	}
 	defer conn.Close()
 	client := pbrpc.NewPocClient(conn)
 	stopServerReq := &pbrpc.RPCStopServerRequest{}
-	log.Printf("rpcclient:StopServerReq: sending=%v", stopServerReq)
+	logger.Debugf("rpcclient:StopServerReq: sending=%v", stopServerReq)
 	res, err := client.StopServer(context.Background(), stopServerReq)
 	if err != nil {
-		log.Fatal(err)
+		logger.Fatalf("Failed to stop RPC server at %v, err: %v", rpcAddr, err)
 	}
-	fmt.Print(res)
+	logger.Debugf("rpcclient:StopServer: result=%v", res)
 }

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -20,7 +20,7 @@ import (
 	logging "github.com/ipfs/go-log"
 )
 
-var logger = logging.Logger("tracing")
+var logger = logging.Logger("sharding-p2p")
 
 type server struct {
 	pbrpc.PocServer

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
 	"math/rand"
 	"net"
 	"os"
@@ -16,11 +15,7 @@ import (
 	pstore "github.com/libp2p/go-libp2p-peerstore"
 	ma "github.com/multiformats/go-multiaddr"
 	"google.golang.org/grpc"
-
-	logging "github.com/ipfs/go-log"
 )
-
-var logger = logging.Logger("sharding-p2p")
 
 type server struct {
 	pbrpc.PocServer
@@ -79,11 +74,12 @@ func (s *server) AddPeer(
 	spanctx, err := logger.StartFromParentState(ctx, "RPCServer.AddPeer", s.serializedSpanCtx)
 	if err != nil {
 		logger.FinishWithErr(spanctx, fmt.Errorf("Failed to deserialize parent span context, err: %v", err))
+		logger.Debugf("Failed to deserialze the trace context. Tracer won't be able to put rpc call traces together. err: %v", err)
 	}
 	defer logger.Finish(spanctx)
 
 	failureMsg := fmt.Sprintf("Failed to add Peer %v:%v", req.Ip, req.Port)
-	log.Printf("rpcserver:AddPeer: receive=%v", req)
+	logger.Debugf("rpcserver:AddPeer: receive=%v", req)
 	_, targetPID, err := makeKey(int(req.Seed))
 	mAddr := fmt.Sprintf(
 		"/ip4/%s/tcp/%d/ipfs/%s",
@@ -93,21 +89,21 @@ func (s *server) AddPeer(
 	)
 	if err != nil {
 		logger.FinishWithErr(spanctx, fmt.Errorf("Failed to generate peer key/ID with seed: %v, err: %v", req.Seed, err))
-		log.Printf("Failed to generate peer key/ID with seed: %v, err: %v", req.Seed, err)
+		logger.Errorf("Failed to generate peer key/ID with seed: %v, err: %v", req.Seed, err)
 		return makePlainResponse(false, failureMsg), nil
 	}
 
 	peerid, targetAddr, err := parseAddr(mAddr)
 	if err != nil {
 		logger.FinishWithErr(spanctx, fmt.Errorf("Failed to parse peer address: %s, err: %v", mAddr, err))
-		log.Printf("Failed to parse peer address: %s, err: %v", mAddr, err)
+		logger.Errorf("Failed to parse peer address: %s, err: %v", mAddr, err)
 		return makePlainResponse(false, failureMsg), nil
 	}
 	s.node.Peerstore().AddAddr(peerid, targetAddr, pstore.PermanentAddrTTL)
 
 	if err := s.node.Connect(ctx, s.node.Peerstore().PeerInfo(peerid)); err != nil {
 		logger.FinishWithErr(spanctx, fmt.Errorf("Failed to connect to peer %v, err: %v", peerid, err))
-		log.Printf("Failed to connect to peer %v, err: %v", peerid, err)
+		logger.Errorf("Failed to connect to peer %v, err: %v", peerid, err)
 		return makePlainResponse(false, failureMsg), nil
 	}
 	replyMsg := fmt.Sprintf(
@@ -129,15 +125,16 @@ func (s *server) SubscribeShard(
 	spanctx, err := logger.StartFromParentState(ctx, "RPCServer.SubscribeShard", s.serializedSpanCtx)
 	if err != nil {
 		logger.FinishWithErr(spanctx, fmt.Errorf("Failed to deserialize parent span context, err: %v", err))
+		logger.Debugf("Failed to deserialze the trace context. Tracer won't be able to put rpc call traces together. err: %v", err)
 	}
 	defer logger.Finish(spanctx)
 
 	subscribedShardID := make([]int64, 0)
-	log.Printf("rpcserver:SubscribeShardRequest: receive=%v", req)
+	logger.Debugf("rpcserver:SubscribeShardRequest: receive=%v", req)
 	for _, shardID := range req.ShardIDs {
 		if err := s.node.ListenShard(spanctx, shardID); err != nil {
 			logger.SetErr(spanctx, fmt.Errorf("Failed to listen to shard %v", shardID))
-			log.Printf("Failed to listen to shard %v", shardID)
+			logger.Errorf("Failed to listen to shard %v", shardID)
 		} else {
 			subscribedShardID = append(subscribedShardID, shardID)
 		}
@@ -161,15 +158,16 @@ func (s *server) UnsubscribeShard(
 	spanctx, err := logger.StartFromParentState(ctx, "RPCServer.UnsubscribeShard", s.serializedSpanCtx)
 	if err != nil {
 		logger.FinishWithErr(spanctx, fmt.Errorf("Failed to deserialize parent span context, err: %v", err))
+		logger.Debugf("Failed to deserialze the trace context. Tracer won't be able to put rpc call traces together. err: %v", err)
 	}
 	defer logger.Finish(spanctx)
 
 	unsubscribedShardID := make([]int64, 0)
-	log.Printf("rpcserver:UnsubscribeShardRequest: receive=%v", req)
+	logger.Debugf("rpcserver:UnsubscribeShardRequest: receive=%v", req)
 	for _, shardID := range req.ShardIDs {
 		if err := s.node.UnlistenShard(spanctx, shardID); err != nil {
 			logger.SetErr(spanctx, fmt.Errorf("Failed to unlisten shard %v", shardID))
-			log.Printf("Failed to unlisten shard %v", shardID)
+			logger.Errorf("Failed to unlisten shard %v", shardID)
 		} else {
 			unsubscribedShardID = append(unsubscribedShardID, shardID)
 		}
@@ -192,10 +190,11 @@ func (s *server) GetSubscribedShard(
 	spanctx, err := logger.StartFromParentState(ctx, "RPCServer.GetSubscribedShard", s.serializedSpanCtx)
 	if err != nil {
 		logger.FinishWithErr(spanctx, fmt.Errorf("Failed to deserialize parent span context, err: %v", err))
+		logger.Debugf("Failed to deserialze the trace context. Tracer won't be able to put rpc call traces together. err: %v", err)
 	}
 	defer logger.Finish(spanctx)
 
-	log.Printf("rpcserver:GetSubscribedShard: receive=%v", req)
+	logger.Debugf("rpcserver:GetSubscribedShard: receive=%v", req)
 	shardIDs := s.node.GetListeningShards()
 	res := &pbrpc.RPCGetSubscribedShardResponse{
 		Response: makeResponse(true, ""),
@@ -213,10 +212,11 @@ func (s *server) BroadcastCollation(
 	spanctx, err := logger.StartFromParentState(ctx, "RPCServer.BroadcastCollation", s.serializedSpanCtx)
 	if err != nil {
 		logger.FinishWithErr(spanctx, fmt.Errorf("Failed to deserialize parent span context, err: %v", err))
+		logger.Debugf("Failed to deserialze the trace context. Tracer won't be able to put rpc call traces together. err: %v", err)
 	}
 	defer logger.Finish(spanctx)
 
-	log.Printf("rpcserver:BroadcastCollationRequest: receive=%v", req)
+	logger.Debugf("rpcserver:BroadcastCollationRequest: receive=%v", req)
 	shardID := req.ShardID
 	numCollations := int(req.Number)
 	timeInMs := req.Period
@@ -237,7 +237,7 @@ func (s *server) BroadcastCollation(
 		)
 		if err != nil {
 			failureMsg := fmt.Sprintf("broadcastcollation fails: %v", err)
-			log.Println(failureMsg)
+			logger.Error(failureMsg)
 			logger.SetErr(spanctx, fmt.Errorf("Failed to broadcast collation"))
 			return makePlainResponse(false, failureMsg), err
 		}
@@ -262,15 +262,16 @@ func (s *server) SendCollation(
 	spanctx, err := logger.StartFromParentState(ctx, "RPCServer.SendCollation", s.serializedSpanCtx)
 	if err != nil {
 		logger.FinishWithErr(spanctx, fmt.Errorf("Failed to deserialize parent span context, err: %v", err))
+		logger.Debugf("Failed to deserialze the trace context. Tracer won't be able to put rpc call traces together. err: %v", err)
 	}
 	defer logger.Finish(spanctx)
 
-	log.Printf("rpcserver:SendCollationRequest: receive=%v", req)
+	logger.Debugf("rpcserver:SendCollationRequest: receive=%v", req)
 	collation := req.Collation
 	err = s.node.broadcastCollationMessage(collation)
 	if err != nil {
 		failureMsg := fmt.Sprintf("broadcastcollation failed: %v", err)
-		log.Println(failureMsg)
+		logger.Error(failureMsg)
 		logger.FinishWithErr(spanctx, fmt.Errorf("Failed to broadcast collation message, err: %v", err))
 		return makePlainResponse(false, failureMsg), err
 	}
@@ -294,13 +295,14 @@ func (s *server) StopServer(
 	spanctx, err := logger.StartFromParentState(ctx, "RPCServer.StopServer", s.serializedSpanCtx)
 	if err != nil {
 		logger.FinishWithErr(spanctx, fmt.Errorf("Failed to deserialize parent span context, err: %v", err))
+		logger.Debugf("Failed to deserialze the trace context. Tracer won't be able to put rpc call traces together. err: %v", err)
 	}
 	defer logger.Finish(spanctx)
 
-	log.Printf("rpcserver:StopServer: receive=%v", req)
-	log.Printf("Closing RPC server by rpc call...")
+	logger.Debugf("rpcserver:StopServer: receive=%v", req)
 	go func() {
 		time.Sleep(time.Second * 1)
+		logger.Info("Closing RPC server by rpc call...")
 		s.rpcServer.Stop()
 	}()
 
@@ -309,6 +311,7 @@ func (s *server) StopServer(
 }
 
 func runRPCServer(n *Node, addr string) {
+	// logging.SetLogLevel("sharding-p2p", "DEBUG")
 	// Start a new trace
 	ctx := context.Background()
 	ctx = logger.Start(ctx, "RPCServer")
@@ -317,12 +320,13 @@ func runRPCServer(n *Node, addr string) {
 	serializedSpanCtx, err := logger.SerializeContext(ctx)
 	if err != nil {
 		logger.FinishWithErr(ctx, fmt.Errorf("Failed to serialize span context, err: %v", err))
+		logger.Debugf("Failed to serialze the trace context. Tracer won't be able to put rpc call traces together, err: %v", err)
 	}
 
 	lis, err := net.Listen("tcp", addr)
 	if err != nil {
 		logger.FinishWithErr(ctx, fmt.Errorf("Failed to set up a service listening on %s, err: %v", addr, err))
-		log.Fatalf("Failed to set up a service listening on %s, err: %v", addr, err)
+		logger.Panicf("Failed to set up a service listening on %s, err: %v", addr, err)
 	}
 	s := grpc.NewServer()
 	pbrpc.RegisterPocServer(s, &server{node: n, serializedSpanCtx: serializedSpanCtx, rpcServer: s})
@@ -332,13 +336,13 @@ func runRPCServer(n *Node, addr string) {
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-c
-		log.Printf("Closing RPC server by Interrupt signal...")
+		logger.Info("Closing RPC server by Interrupt signal...")
 		s.Stop()
 	}()
 
-	log.Printf("rpcserver: listening to %v", addr)
+	logger.Info("RPC server listening to address: %v", addr)
 	if err := s.Serve(lis); err != nil {
 		logger.FinishWithErr(ctx, fmt.Errorf("Failed to serve the RPC server, err: %v", err))
-		log.Fatalf("Failed to serve the RPC server, err: %v", err)
+		logger.Panicf("Failed to serve the RPC server, err: %v", err)
 	}
 }

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -326,7 +326,7 @@ func runRPCServer(n *Node, addr string) {
 	lis, err := net.Listen("tcp", addr)
 	if err != nil {
 		logger.FinishWithErr(ctx, fmt.Errorf("Failed to set up a service listening on %s, err: %v", addr, err))
-		logger.Panicf("Failed to set up a service listening on %s, err: %v", addr, err)
+		logger.Fatalf("Failed to set up a service listening on %s, err: %v", addr, err)
 	}
 	s := grpc.NewServer()
 	pbrpc.RegisterPocServer(s, &server{node: n, serializedSpanCtx: serializedSpanCtx, rpcServer: s})
@@ -343,6 +343,6 @@ func runRPCServer(n *Node, addr string) {
 	logger.Info("RPC server listening to address: %v", addr)
 	if err := s.Serve(lis); err != nil {
 		logger.FinishWithErr(ctx, fmt.Errorf("Failed to serve the RPC server, err: %v", err))
-		logger.Panicf("Failed to serve the RPC server, err: %v", err)
+		logger.Fatalf("Failed to serve the RPC server, err: %v", err)
 	}
 }

--- a/script/partial-gx-uw.py
+++ b/script/partial-gx-uw.py
@@ -8,7 +8,6 @@ import re
 
 unwrite_pkgs = (
     "github.com/opentracing/opentracing-go",
-    "github.com/gogo/protobuf/proto",
 )
 
 URL_DELIMETER = '/'

--- a/shardmanager.go
+++ b/shardmanager.go
@@ -33,10 +33,14 @@ const collationTopicFmt = "shardCollations_%d"
 type TopicValidator = pubsub.Validator
 type TopicHandler = func(ctx context.Context, msg *pubsub.Message)
 
-func getCollationHash(msg *pbmsg.Collation) string {
-	hashBytes := keccak(msg)
+func getCollationHash(msg *pbmsg.Collation) (string, error) {
+	hashBytes, err := keccak(msg)
+	if err != nil {
+		logger.Errorf("Failed to hash the given message: %v, err: %v", msg, err)
+		return "", err
+	}
 	// FIXME: for convenience
-	return b58.Encode(hashBytes)
+	return b58.Encode(hashBytes), nil
 }
 
 func getCollationsTopic(shardID ShardIDType) string {

--- a/shardmanager.go
+++ b/shardmanager.go
@@ -50,7 +50,7 @@ func getCollationsTopic(shardID ShardIDType) string {
 func NewShardManager(ctx context.Context, h host.Host, eventNotifier EventNotifier) *ShardManager {
 	service, err := pubsub.NewGossipSub(ctx, h)
 	if err != nil {
-		logger.Panicf("Failed to create new pubsub service, err: %v", err)
+		logger.Fatalf("Failed to create new pubsub service, err: %v", err)
 	}
 	p := &ShardManager{
 		ctx:            ctx,
@@ -63,7 +63,7 @@ func NewShardManager(ctx context.Context, h host.Host, eventNotifier EventNotifi
 	}
 	err = p.SubscribeListeningShards()
 	if err != nil {
-		logger.Panicf("Failed to subscribe to global topic 'listeningShard', err: %v", err)
+		logger.Fatalf("Failed to subscribe to global topic 'listeningShard', err: %v", err)
 	}
 	return p
 }

--- a/shardmanager.go
+++ b/shardmanager.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
 	"sync"
 
 	pubsub "github.com/libp2p/go-floodsub"
@@ -47,7 +46,7 @@ func getCollationsTopic(shardID ShardIDType) string {
 func NewShardManager(ctx context.Context, h host.Host, eventNotifier EventNotifier) *ShardManager {
 	service, err := pubsub.NewGossipSub(ctx, h)
 	if err != nil {
-		log.Fatalln(err)
+		logger.Panicf("Failed to create new pubsub service, err: %v", err)
 	}
 	p := &ShardManager{
 		ctx:            ctx,
@@ -60,7 +59,7 @@ func NewShardManager(ctx context.Context, h host.Host, eventNotifier EventNotifi
 	}
 	err = p.SubscribeListeningShards()
 	if err != nil {
-		log.Fatalln(err)
+		logger.Panicf("Failed to subscribe to global topic 'listeningShard', err: %v", err)
 	}
 	return p
 }
@@ -101,7 +100,7 @@ func (n *ShardManager) connectShardNodes(ctx context.Context, shardID ShardIDTyp
 			defer wg.Done()
 			if err := n.host.Connect(spanctx, p); err != nil {
 				logger.SetErr(childSpanctx, fmt.Errorf("Failed to connect peer %v in shard %v, err: %v", p.ID, shardID, err))
-				log.Printf(
+				logger.Errorf(
 					"Failed to connect peer %v in shard %v: %s",
 					p.ID,
 					shardID,
@@ -109,7 +108,7 @@ func (n *ShardManager) connectShardNodes(ctx context.Context, shardID ShardIDTyp
 				)
 				return
 			}
-			log.Printf("Successfully connected peer %v in shard %v", p.ID, shardID)
+			logger.Debugf("Successfully connected peer %v in shard %v", p.ID, shardID)
 			logger.SetTag(childSpanctx, "peer", p.ID)
 		}(p)
 	}
@@ -130,14 +129,14 @@ func (n *ShardManager) ListenShard(ctx context.Context, shardID ShardIDType) err
 
 	// TODO: should set a critiria: if we have enough peers in the shard, don't connect shard nodes
 	if err := n.connectShardNodes(spanctx, shardID); err != nil {
-		logger.FinishWithErr(spanctx, fmt.Errorf("Failed to connect to nodes in shard %v", shardID))
-		log.Printf("Failed to connect to nodes in shard %v", shardID)
+		logger.SetErr(spanctx, fmt.Errorf("Failed to connect to nodes in shard %v", shardID))
+		logger.Errorf("Failed to connect to nodes in shard %v", shardID)
 	}
 
 	// shardCollations protocol
 	if err := n.SubscribeCollation(spanctx, shardID); err != nil {
 		logger.FinishWithErr(spanctx, fmt.Errorf("Failed to subscribe to collation in shard %v", shardID))
-		log.Printf("Failed to subscribe to collation in shard %v", shardID)
+		logger.Errorf("Failed to subscribe to collation in shard %v", shardID)
 		return err
 	}
 
@@ -201,7 +200,7 @@ func (n *ShardManager) SubscribeTopic(
 
 	sub, err := n.pubsubService.Subscribe(topic)
 	if err != nil {
-		log.Printf("Failed to subscribe to topic: %s", topic)
+		logger.Errorf("Failed to subscribe to topic: %s", topic)
 		logger.FinishWithErr(spanctx, fmt.Errorf("Failed to subscribe to topic: %s, err: %v", topic, err))
 		return err
 	}
@@ -288,7 +287,7 @@ func (n *ShardManager) PublishListeningShards(ctx context.Context) {
 	bytes := selfListeningShards.toBytes()
 	if err := n.pubsubService.Publish(listeningShardTopic, bytes); err != nil {
 		logger.SetErr(spanctx, fmt.Errorf("Failed to publish listening shards, err: %v", err))
-		log.Println("Failed to publish listening shards")
+		logger.Errorf("Failed to publish data '%v' to topic '%v', err: %v", bytes, listeningShardTopic, err)
 	}
 }
 
@@ -371,7 +370,7 @@ func (n *ShardManager) broadcastCollation(
 	err := n.broadcastCollationMessage(data)
 	if err != nil {
 		logger.SetErr(spanctx, fmt.Errorf("Failed to broadcast collation message, err: %v", err))
-		log.Println("Failed to broadcast collation message")
+		logger.Errorf("Failed to broadcast collation message")
 		return err
 	}
 
@@ -388,12 +387,12 @@ func (n *ShardManager) broadcastCollationMessage(collation *pbmsg.Collation) err
 	collationsTopic := getCollationsTopic(collation.ShardID)
 	bytes, err := proto.Marshal(collation)
 	if err != nil {
-		log.Println(err)
+		logger.Errorf("Failed to encode protobuf message: %v, err: %v", collation, err)
 		return err
 	}
 	err = n.pubsubService.Publish(collationsTopic, bytes)
 	if err != nil {
-		log.Println(err)
+		logger.Errorf("Failed to publish data '%v' to topic '%v', err: %v", bytes, collationsTopic, err)
 		return err
 	}
 	return nil

--- a/shardpreftable.go
+++ b/shardpreftable.go
@@ -40,7 +40,6 @@ func (ls *ListeningShards) unsetShard(shardID ShardIDType) error {
 			len(ls.shardBits),
 		)
 	}
-	// log.Printf("shardID=%v, byteIndex=%v, bitIndex=%v", shardID, byteIndex, bitIndex)
 	ls.shardBits[byteIndex] &= (^(1 << bitIndex))
 	return nil
 }
@@ -57,7 +56,6 @@ func (ls *ListeningShards) setShard(shardID ShardIDType) error {
 			len(ls.shardBits),
 		)
 	}
-	// log.Printf("shardID=%v, byteIndex=%v, bitIndex=%v", shardID, byteIndex, bitIndex)
 	ls.shardBits[byteIndex] |= (1 << bitIndex)
 	return nil
 }

--- a/utils.go
+++ b/utils.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"log"
-
 	"golang.org/x/crypto/sha3"
 
 	"github.com/golang/protobuf/proto"
@@ -11,7 +9,7 @@ import (
 func keccak(msg proto.Message) []byte {
 	dataInBytes, err := proto.Marshal(msg)
 	if err != nil {
-		log.Printf("Error occurs when hashing %v", msg)
+		logger.Panicf("Failed to encode protobuf message: %v, err: %v", msg, err)
 	}
 	h := sha3.NewLegacyKeccak256()
 	h.Write(dataInBytes)

--- a/utils.go
+++ b/utils.go
@@ -6,12 +6,15 @@ import (
 	"github.com/golang/protobuf/proto"
 )
 
-func keccak(msg proto.Message) []byte {
+func keccak(msg proto.Message) ([]byte, error) {
 	dataInBytes, err := proto.Marshal(msg)
 	if err != nil {
-		logger.Panicf("Failed to encode protobuf message: %v, err: %v", msg, err)
+		logger.Errorf("Failed to encode protobuf message: %v, err: %v", msg, err)
+		return nil, err
 	}
 	h := sha3.NewLegacyKeccak256()
-	h.Write(dataInBytes)
-	return h.Sum(nil)
+	if _, err := h.Write(dataInBytes); err != nil {
+		return nil, err
+	}
+	return h.Sum(nil), nil
 }


### PR DESCRIPTION
## How was it fixed?
- [x] Replace built-in logger with go-log logger
    - `Panic`, `Fatal`, `Error`, `Warning`, `Info`, `Debug`
- [x] Add RPC option for setting logger level
    - levels: `Critical`, `Error`, `Warning`, `Notice`, `Info`, `Debug`
    - Default to?
        `INFO`



#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](
https://c.pxhere.com/photos/25/ce/wild_animal_oregon_zoo_cub_feline_funny_play-521518.jpg!d)
