### PR TITLE
Run `go build` in docker build

### DIFF
--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -4,5 +4,6 @@ COPY . /go/src/github.com/ethresearch/sharding-p2p-poc
 RUN apk add git python3 make
 RUN go get -d -v .
 RUN make deps
+RUN go build
 
-CMD ["sh"]
+CMD ["./sharding-p2p-poc"]


### PR DESCRIPTION
### What was wrong?
Previous `dev.Dockerfile` doesn't run `go build` in `docker build`, which make it harder to test directly without running `go build` when start running the container.

### How was it fixed?
Add `go build` in `dev.Dockerfile`, and run the executable when `docker run`.


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://scontent-tpe1-1.xx.fbcdn.net/v/t1.0-9/42572731_1070568453137555_4617194485783199744_n.jpg?_nc_cat=1&oh=95498235f94945613fe3e491175a7ba6&oe=5C1B3A45)
