### PR TITLE
Remove unnecessary dependencies from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,65 +23,6 @@
       "hash": "QmXScvRbYh9X9okLuX9YMnz1HR4WgRTU2hocjBs15nmCNG",
       "name": "go-libp2p-floodsub",
       "version": "0.9.21"
-    },
-    {
-      "author": "jbenet",
-      "hash": "QmeiCcJfDW1GJnWUArudsv5rQsihpi4oyddPhdqo3CfX6i",
-      "name": "go-datastore",
-      "version": "2.4.1"
-    },
-    {
-      "hash": "QmcVVHfdyv15GVPk7NrxdWjh2hLVccXnoD8j2tyQShiXJb",
-      "name": "go-log",
-      "version": "1.5.3"
-    },
-    {
-      "author": "whyrusleeping",
-      "hash": "Qme1knMqwt1hKZbc1BmQFmnm9f36nyQGwXxPGVpVJ9rMK5",
-      "name": "go-libp2p-crypto",
-      "version": "1.6.2"
-    },
-    {
-      "author": "whyrusleeping",
-      "hash": "Qmb8T6YBBsjYsVGfrihQLfCJveczZnneSBqBKkYEBWDjge",
-      "name": "go-libp2p-host",
-      "version": "3.0.4"
-    },
-    {
-      "author": "whyrusleeping",
-      "hash": "QmPjvxTpVH8qJyQDnxnsxF9kv9jezKD1kozz1hs3fCGsNh",
-      "name": "go-libp2p-net",
-      "version": "3.0.5"
-    },
-    {
-      "author": "whyrusleeping",
-      "hash": "QmdVrMn1LhB4ybb8hMVaMLXnA8XRSewMnK6YqXKXoTcRvN",
-      "name": "go-libp2p-peer",
-      "version": "2.3.5"
-    },
-    {
-      "author": "whyrusleeping",
-      "hash": "QmZR2XWVVBCtbgBWnQhWk2xcQfaR3W8faQPriAiaaj7rsr",
-      "name": "go-libp2p-peerstore",
-      "version": "1.4.22"
-    },
-    {
-      "author": "whyrusleeping",
-      "hash": "QmZNkThpqfVXs9GNbexPrfBbXSLNYeKrE7jwFM2oqHbyqN",
-      "name": "go-libp2p-protocol",
-      "version": "1.0.0"
-    },
-    {
-      "author": "multiformats",
-      "hash": "QmYmsdtJ3HsodkePE3eU3TsCaP2YvPZJ4LoXnNkDE5Tpt7",
-      "name": "go-multiaddr",
-      "version": "1.3.0"
-    },
-    {
-      "author": "multiformats",
-      "hash": "QmRDePEiL4Yupq5EkcK3L3ko3iMgYaqUdLu7xc1kqs7dnV",
-      "name": "go-multicodec",
-      "version": "0.1.5"
     }
   ],
   "gxVersion": "0.12.1",


### PR DESCRIPTION
These dependencies are already transitively imported from `go-libp2p` or others.