### PR TITLE
Update deps' versions

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"strings"
 
-	// gologging "gx/ipfs/QmQvJiADDe7JR4m968MwXobTCCzUqQkP87aRHe29MEBGHV/go-logging"
 	ds "github.com/ipfs/go-datastore"
 	dsync "github.com/ipfs/go-datastore/sync"
 	logging "github.com/ipfs/go-log"

--- a/package.json
+++ b/package.json
@@ -9,14 +9,14 @@
   "gxDependencies": [
     {
       "author": "whyrusleeping",
-      "hash": "QmY51bqSM5XgxQZqsBrQcRkKTnCb8EKpJpR9K6Qax7Njco",
+      "hash": "QmNmj2AeM46ZQqHARnWidb5qqHoZJFeYWzmG65jviJDRQY",
       "name": "go-libp2p",
-      "version": "6.0.6"
+      "version": "6.0.15"
     },
     {
-      "hash": "QmfBGjnPFqyJbPr8aSqEkQMfNkJUheD8mjxZ3jxkeYMFB3",
+      "hash": "QmXKSnQHAihkcGgk8ZXz7FgZgHboXeRduuEz9FkAddJK6P",
       "name": "go-libp2p-kad-dht",
-      "version": "4.3.0"
+      "version": "4.4.4"
     },
     {
       "author": "whyrusleeping",

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmXScvRbYh9X9okLuX9YMnz1HR4WgRTU2hocjBs15nmCNG",
+      "hash": "QmUK4h113Hh7bR2gPpsMcbUEbbzc7hspocmPi91Bmi69nH",
       "name": "go-libp2p-floodsub",
-      "version": "0.9.21"
+      "version": "0.9.31"
     }
   ],
   "gxVersion": "0.12.1",


### PR DESCRIPTION
### What was wrong?
Dep version of `go-floodsub`, `go-libp2p`, `go-libp2p-kad-dht` are stale. There were multiple fixes during these months in `go-floodsub`. We should make use of the fixes

### How was it fixed?
Update it to the latest version, and also remove some unnecessary workaround which are no longer needed due to those fixes.


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://scontent.ftpe7-1.fna.fbcdn.net/v/t1.0-9/41962055_1065600170301050_1763828976955949056_n.jpg?_nc_cat=110&oh=82b3f62fd99a8a34b4f97c63013f5cd8&oe=5C19B445)
