### PR TITLE
Abstract discovery

### DIFF
--- a/discovery.go
+++ b/discovery.go
@@ -47,6 +47,10 @@ func (gt *GlobalTable) FindPeers(ctx context.Context, shardID ShardIDType) ([]ps
 	peerIDs := gt.shardPrefTable.GetPeersInShard(shardID)
 	pinfos := []pstore.PeerInfo{}
 	for _, peerID := range peerIDs {
+		// Exclude ourself
+		if peerID == gt.host.ID() {
+			continue
+		}
 		pi := gt.host.Peerstore().PeerInfo(peerID)
 		pinfos = append(pinfos, pi)
 	}

--- a/discovery.go
+++ b/discovery.go
@@ -29,8 +29,8 @@ func NewGlobalTable(ctx context.Context, h host.Host, pubsubService *pubsub.PubS
 }
 
 func (gt *GlobalTable) Advertise(ctx context.Context, shardID ShardIDType) error {
-	// If we've not yet subscribed to this shard, subscribe it
-	// If we've already subscribed to this shard, unsubscribe it
+	// If we've not yet subscribed to this shard, add it to shardPrefTable
+	// If we've already subscribed to this shard, remove it from shardPrefTable
 	if gt.shardPrefTable.IsPeerListeningShard(gt.host.ID(), shardID) {
 		if err := gt.shardPrefTable.RemovePeerListeningShard(gt.host.ID(), shardID); err != nil {
 			return err

--- a/discovery.go
+++ b/discovery.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"context"
+
+	pstore "github.com/libp2p/go-libp2p-peerstore"
+)
+
+type Discovery interface {
+	Advertise(ctx context.Context, topic string) error
+	FindPeers(ctx context.Context, topic string) ([]pstore.PeerInfo, error)
+}

--- a/discovery.go
+++ b/discovery.go
@@ -3,10 +3,26 @@ package main
 import (
 	"context"
 
+	pubsub "github.com/libp2p/go-floodsub"
+	host "github.com/libp2p/go-libp2p-host"
 	pstore "github.com/libp2p/go-libp2p-peerstore"
 )
 
 type Discovery interface {
 	Advertise(ctx context.Context, shardID ShardIDType) error
 	FindPeers(ctx context.Context, shardID ShardIDType) ([]pstore.PeerInfo, error)
+}
+
+type GlobalTable struct {
+	host           host.Host
+	pubsubService  *pubsub.PubSub
+	shardPrefTable *ShardPrefTable
+}
+
+func NewGlobalTable(ctx context.Context, h host.Host, pubsubService *pubsub.PubSub, shardPrefTable *ShardPrefTable) *GlobalTable {
+	return &GlobalTable{
+		host:           h,
+		pubsubService:  pubsubService,
+		shardPrefTable: shardPrefTable,
+	}
 }

--- a/discovery.go
+++ b/discovery.go
@@ -41,3 +41,14 @@ func (gt *GlobalTable) Advertise(ctx context.Context, shardID ShardIDType) error
 
 	return nil
 }
+
+func (gt *GlobalTable) FindPeers(ctx context.Context, shardID ShardIDType) ([]pstore.PeerInfo, error) {
+	// Get peer ID from local table and convert to PeerInfo format
+	peerIDs := gt.shardPrefTable.GetPeersInShard(shardID)
+	pinfos := []pstore.PeerInfo{}
+	for _, peerID := range peerIDs {
+		pi := gt.host.Peerstore().PeerInfo(peerID)
+		pinfos = append(pinfos, pi)
+	}
+	return pinfos, nil
+}

--- a/discovery.go
+++ b/discovery.go
@@ -32,9 +32,13 @@ func (gt *GlobalTable) Advertise(ctx context.Context, shardID ShardIDType) error
 	// If we've not yet subscribed to this shard, subscribe it
 	// If we've already subscribed to this shard, unsubscribe it
 	if gt.shardPrefTable.IsPeerListeningShard(gt.host.ID(), shardID) {
-		gt.shardPrefTable.RemovePeerListeningShard(gt.host.ID(), shardID)
+		if err := gt.shardPrefTable.RemovePeerListeningShard(gt.host.ID(), shardID); err != nil {
+			return err
+		}
 	} else {
-		gt.shardPrefTable.AddPeerListeningShard(gt.host.ID(), shardID)
+		if err := gt.shardPrefTable.AddPeerListeningShard(gt.host.ID(), shardID); err != nil {
+			return err
+		}
 	}
 
 	// Publish our preference in local table

--- a/discovery.go
+++ b/discovery.go
@@ -29,8 +29,13 @@ func NewGlobalTable(ctx context.Context, h host.Host, pubsubService *pubsub.PubS
 }
 
 func (gt *GlobalTable) Advertise(ctx context.Context, shardID ShardIDType) error {
-	// Modify local table
-	gt.shardPrefTable.AddPeerListeningShard(gt.host.ID(), shardID)
+	// If we've not yet subscribed to this shard, subscribe it
+	// If we've already subscribed to this shard, unsubscribe it
+	if gt.shardPrefTable.IsPeerListeningShard(gt.host.ID(), shardID) {
+		gt.shardPrefTable.RemovePeerListeningShard(gt.host.ID(), shardID)
+	} else {
+		gt.shardPrefTable.AddPeerListeningShard(gt.host.ID(), shardID)
+	}
 
 	// Publish our preference in local table
 	selfListeningShards := gt.shardPrefTable.GetPeerListeningShard(gt.host.ID()).toBytes()

--- a/discovery.go
+++ b/discovery.go
@@ -7,6 +7,6 @@ import (
 )
 
 type Discovery interface {
-	Advertise(ctx context.Context, topic string) error
-	FindPeers(ctx context.Context, topic string) ([]pstore.PeerInfo, error)
+	Advertise(ctx context.Context, shardID ShardIDType) error
+	FindPeers(ctx context.Context, shardID ShardIDType) ([]pstore.PeerInfo, error)
 }

--- a/discovery.go
+++ b/discovery.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	pubsub "github.com/libp2p/go-floodsub"
 	host "github.com/libp2p/go-libp2p-host"
@@ -10,8 +11,8 @@ import (
 )
 
 type Discovery interface {
-	Advertise(ctx context.Context, shardID ShardIDType) error
-	FindPeers(ctx context.Context, shardID ShardIDType) ([]pstore.PeerInfo, error)
+	Advertise(ctx context.Context, topic string) error
+	FindPeers(ctx context.Context, topic string) ([]pstore.PeerInfo, error)
 }
 
 type GlobalTable struct {
@@ -28,7 +29,11 @@ func NewGlobalTable(ctx context.Context, h host.Host, pubsubService *pubsub.PubS
 	}
 }
 
-func (gt *GlobalTable) Advertise(ctx context.Context, shardID ShardIDType) error {
+func (gt *GlobalTable) Advertise(ctx context.Context, topic string) error {
+	shardID, err := strconv.ParseInt(topic, 10, 64)
+	if err != nil {
+		return err
+	}
 	// If we've not yet subscribed to this shard, add it to shardPrefTable
 	// If we've already subscribed to this shard, remove it from shardPrefTable
 	if gt.shardPrefTable.IsPeerListeningShard(gt.host.ID(), shardID) {
@@ -51,7 +56,11 @@ func (gt *GlobalTable) Advertise(ctx context.Context, shardID ShardIDType) error
 	return nil
 }
 
-func (gt *GlobalTable) FindPeers(ctx context.Context, shardID ShardIDType) ([]pstore.PeerInfo, error) {
+func (gt *GlobalTable) FindPeers(ctx context.Context, topic string) ([]pstore.PeerInfo, error) {
+	shardID, err := strconv.ParseInt(topic, 10, 64)
+	if err != nil {
+		return nil, err
+	}
 	// Get peer ID from local table and convert to PeerInfo format
 	peerIDs := gt.shardPrefTable.GetPeersInShard(shardID)
 	pinfos := []pstore.PeerInfo{}

--- a/main_test.go
+++ b/main_test.go
@@ -467,11 +467,6 @@ func TestPubSubNotifyListeningShards(t *testing.T) {
 	connectBarbell(t, ctx, nodes)
 	waitForPubSubMeshBuilt()
 
-	// ensure notifyShards message is propagated through node1
-	if len(nodes[1].shardPrefTable.GetPeerListeningShardSlice(nodes[0].ID())) != 0 {
-		t.Error()
-	}
-
 	if err := nodes[0].ListenShard(ctx, 42); err != nil {
 		t.Errorf("Failed to listen to shard 42")
 	}
@@ -479,10 +474,10 @@ func TestPubSubNotifyListeningShards(t *testing.T) {
 	time.Sleep(time.Millisecond * 100)
 
 	if len(nodes[1].shardPrefTable.GetPeerListeningShardSlice(nodes[0].ID())) != 1 {
-		t.Error()
+		t.Error("Node 0 should subscribe to exactly one shard")
 	}
 	if len(nodes[2].shardPrefTable.GetPeerListeningShardSlice(nodes[0].ID())) != 1 {
-		t.Error()
+		t.Error("Node 0 should subscribe to exactly one shard")
 	}
 
 	if err := nodes[1].ListenShard(ctx, 42); err != nil {
@@ -509,7 +504,7 @@ func TestPubSubNotifyListeningShards(t *testing.T) {
 	time.Sleep(time.Millisecond * 100)
 
 	if len(nodes[1].shardPrefTable.GetPeerListeningShardSlice(nodes[0].ID())) != 0 {
-		t.Error()
+		t.Error("Node 0 should not be subscribing to any shard")
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -435,12 +435,10 @@ func TestListenShardConnectingPeers(t *testing.T) {
 	if err := nodes[0].ListenShard(ctx, 0); err != nil {
 		t.Errorf("Failed to listen to shard 0")
 	}
-	nodes[0].PublishListeningShards(ctx)
 
 	if err := nodes[2].ListenShard(ctx, 42); err != nil {
 		t.Errorf("Failed to listen to shard 42")
 	}
-	nodes[2].PublishListeningShards(ctx)
 	// wait for peer to receive shard subscription update
 	time.Sleep(time.Millisecond * 100)
 
@@ -452,7 +450,6 @@ func TestListenShardConnectingPeers(t *testing.T) {
 	if err := nodes[0].ListenShard(ctx, 42); err != nil {
 		t.Errorf("Failed to listen to shard 42")
 	}
-	nodes[0].PublishListeningShards(ctx)
 	// wait for peer to receive shard subscription update
 	time.Sleep(time.Millisecond * 100)
 
@@ -478,7 +475,6 @@ func TestPubSubNotifyListeningShards(t *testing.T) {
 	if err := nodes[0].ListenShard(ctx, 42); err != nil {
 		t.Errorf("Failed to listen to shard 42")
 	}
-	nodes[0].PublishListeningShards(ctx)
 	// wait for peer to receive shard subscription update
 	time.Sleep(time.Millisecond * 100)
 
@@ -492,7 +488,6 @@ func TestPubSubNotifyListeningShards(t *testing.T) {
 	if err := nodes[1].ListenShard(ctx, 42); err != nil {
 		t.Errorf("Failed to listen to shard 42")
 	}
-	nodes[1].PublishListeningShards(ctx)
 	// wait for peer to receive shard subscription update
 	time.Sleep(time.Millisecond * 100)
 
@@ -510,7 +505,6 @@ func TestPubSubNotifyListeningShards(t *testing.T) {
 	if err := nodes[0].UnlistenShard(ctx, 42); err != nil {
 		t.Errorf("Failed to listen to shard 42")
 	}
-	nodes[0].PublishListeningShards(ctx)
 	// wait for peer to receive shard subscription update
 	time.Sleep(time.Millisecond * 100)
 
@@ -530,7 +524,6 @@ func TestBroadcastCollation(t *testing.T) {
 	if err := nodes[0].ListenShard(ctx, testingShardID); err != nil {
 		t.Errorf("Failed to listen to shard %v", testingShardID)
 	}
-	nodes[0].PublishListeningShards(ctx)
 	// wait for peer to receive shard subscription update
 	time.Sleep(time.Millisecond * 100)
 	// TODO: fail: if the receiver didn't subscribe the shard, it should ignore the message
@@ -538,7 +531,6 @@ func TestBroadcastCollation(t *testing.T) {
 	if err := nodes[1].ListenShard(ctx, testingShardID); err != nil {
 		t.Errorf("Failed to listen to shard %v", testingShardID)
 	}
-	nodes[1].PublishListeningShards(ctx)
 	// wait for peer to receive shard subscription update
 	time.Sleep(time.Millisecond * 100)
 	// TODO: fail: if the collation's shardID does not correspond to the protocol's shardID,

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -138,7 +138,6 @@ func (s *server) SubscribeShard(
 		}
 		time.Sleep(time.Millisecond * 30)
 	}
-	s.node.PublishListeningShards(spanctx)
 	replyMsg := fmt.Sprintf(
 		"Subscribed shard %v",
 		req.ShardIDs,
@@ -171,7 +170,6 @@ func (s *server) UnsubscribeShard(
 		}
 		time.Sleep(time.Millisecond * 30)
 	}
-	s.node.PublishListeningShards(spanctx)
 	replyMsg := fmt.Sprintf(
 		"Unsubscribed shard %v",
 		req.ShardIDs,

--- a/shardmanager.go
+++ b/shardmanager.go
@@ -106,6 +106,13 @@ func (n *ShardManager) connectShardNodes(ctx context.Context, shardID ShardIDTyp
 			defer logger.Finish(childSpanctx)
 
 			defer wg.Done()
+
+			// Skip if we already have connection with the peer
+			connsToPeer := n.host.Network().ConnsToPeer(p.ID)
+			if len(connsToPeer) != 0 {
+				return
+			}
+
 			if err := n.host.Connect(spanctx, p); err != nil {
 				logger.SetErr(childSpanctx, fmt.Errorf("Failed to connect peer %v in shard %v, err: %v", p.ID, shardID, err))
 				logger.Errorf(

--- a/shardmanager.go
+++ b/shardmanager.go
@@ -173,7 +173,11 @@ func (n *ShardManager) UnlistenShard(ctx context.Context, shardID ShardIDType) e
 	if !n.IsShardListened(shardID) {
 		return nil
 	}
-	n.shardPrefTable.RemovePeerListeningShard(n.host.ID(), shardID)
+	if err := n.discovery.Advertise(spanctx, shardID); err != nil {
+		logger.SetErr(spanctx, fmt.Errorf("Failed to advertise subscription to shard %v", shardID))
+		logger.Errorf("Failed to advertise subscription to shard %v", shardID)
+		return err
+	}
 
 	// listeningShards protocol
 	// TODO: should we remove some peers in this shard?

--- a/shardmanager.go
+++ b/shardmanager.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"sync"
 
 	pubsub "github.com/libp2p/go-floodsub"
@@ -89,7 +90,7 @@ func (n *ShardManager) connectShardNodes(ctx context.Context, shardID ShardIDTyp
 	defer logger.Finish(spanctx)
 	logger.SetTag(spanctx, "shard", shardID)
 
-	pinfos, err := n.discovery.FindPeers(spanctx, shardID)
+	pinfos, err := n.discovery.FindPeers(spanctx, strconv.FormatInt(shardID, 10))
 	if err != nil {
 		logger.SetErr(spanctx, fmt.Errorf("Failed to find peers in shard %v", shardID))
 		logger.Errorf("Failed to find peers in shard %v", shardID)
@@ -140,7 +141,7 @@ func (n *ShardManager) ListenShard(ctx context.Context, shardID ShardIDType) err
 		return nil
 	}
 
-	if err := n.discovery.Advertise(spanctx, shardID); err != nil {
+	if err := n.discovery.Advertise(spanctx, strconv.FormatInt(shardID, 10)); err != nil {
 		logger.SetErr(spanctx, fmt.Errorf("Failed to advertise subscription to shard %v", shardID))
 		logger.Errorf("Failed to advertise subscription to shard %v", shardID)
 		return err
@@ -172,7 +173,7 @@ func (n *ShardManager) UnlistenShard(ctx context.Context, shardID ShardIDType) e
 	if !n.IsShardListened(shardID) {
 		return nil
 	}
-	if err := n.discovery.Advertise(spanctx, shardID); err != nil {
+	if err := n.discovery.Advertise(spanctx, strconv.FormatInt(shardID, 10)); err != nil {
 		logger.SetErr(spanctx, fmt.Errorf("Failed to advertise subscription to shard %v", shardID))
 		logger.Errorf("Failed to advertise subscription to shard %v", shardID)
 		return err

--- a/shardpreftable_test.go
+++ b/shardpreftable_test.go
@@ -10,28 +10,28 @@ func TestListeningShards(t *testing.T) {
 	ls := NewListeningShards()
 	lsSlice := ls.getShards()
 	if len(lsSlice) != 0 {
-		t.Error()
+		t.Error("Should not have subscribed to any shard")
 	}
 
 	ls.setShard(1)
 	lsSlice = ls.getShards()
 	if (len(lsSlice) != 1) || lsSlice[0] != ShardIDType(1) {
-		t.Error()
+		t.Error("Should only subscribe to shard 1")
 	}
 	ls.setShard(42)
 	if len(ls.getShards()) != 2 {
-		t.Error()
+		t.Error("Should subscribe to exactly two shards")
 	}
 	// test `toBytes` and `fromBytes`
 	bytes := ls.toBytes()
 	lsNew := ls.fromBytes(bytes)
 	if len(ls.getShards()) != len(lsNew.getShards()) {
-		t.Error()
+		t.Error("Failed to convert listening shards between toBytes and fromBytes")
 	}
 	lsNewSlice := lsNew.getShards()
 	for index, value := range ls.getShards() {
 		if value != lsNewSlice[index] {
-			t.Error()
+			t.Error("Shards in the new listerning shard do not match the ones in the old listening shard")
 		}
 	}
 }


### PR DESCRIPTION
### How was it fixed?
- [x] Add Discovery interface
    - `Advertise(ctx context.Context, shardID ShardIDType) error`
        - advertise an already advertised shard => cancel the advertisement on that shard
    - `FindPeers(ctx context.Context, shardID ShardIDType) ([]pstore.PeerInfo, error)`
- [x] Use ShardPrefTable as current discovery mechanism



#### Cute Animal Picture

![](https://www.maxpixel.net/static/photo/2x/Cute-Tom-Funny-Face-Pet-Funny-Animal-Cat-Feline-1496059.jpg)