### PR TITLE
Fix security group and topology loading

### DIFF
--- a/deployment/ansible/.gitignore
+++ b/deployment/ansible/.gitignore
@@ -1,3 +1,3 @@
 *.retry
 hosts
-group_vars/all/topology.yml
+topology.yml

--- a/deployment/ansible/example_run_nodes.yml
+++ b/deployment/ansible/example_run_nodes.yml
@@ -19,8 +19,6 @@
 - name: spin up servers
   hosts: nodes
   gather_facts: false
-  vars_files:
-    - group_vars/all/topology.yml
   roles:
     - role: node
 

--- a/deployment/ansible/roles/common/tasks/cli_addpeer.yml
+++ b/deployment/ansible/roles/common/tasks/cli_addpeer.yml
@@ -1,4 +1,7 @@
 ---
+- name: load topology
+  include_vars:
+    file: topology.yml
 
 - name: call RPC addpeer
   command: "{{item}}"

--- a/deployment/ansible/scripts/topology.py
+++ b/deployment/ansible/scripts/topology.py
@@ -72,5 +72,5 @@ if __name__ == '__main__':
     print("\n")
     yml = topology_to_yaml(topology)
     print(yml)
-    with open("group_vars/all/topology.yml", "w") as f:
+    with open("topology.yml", "w") as f:
         f.write(yml)

--- a/deployment/terraform/example.tf
+++ b/deployment/terraform/example.tf
@@ -14,6 +14,7 @@ resource "aws_instance" "example" {
   tags          = "${var.tags}"
   key_name      = "${var.key_name}"
   count         = "${var.cluster_size}"
+  security_groups=["${aws_security_group.sharding_sim.name}"]
 
   provisioner "remote-exec" {
     # The connection will use the local SSH agent for authentication
@@ -23,5 +24,42 @@ resource "aws_instance" "example" {
     connection {
       user = "${var.vm_user}"
     }
+  }
+}
+
+
+resource "aws_security_group" "sharding_sim" {
+  name        = "Sharding simulation"
+  tags = "${var.tags}"
+
+  # SSH access from anywhere
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # HTTP access from anywhere
+  ingress {
+    from_port   = 0
+    to_port     = 65535
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 0
+    to_port     = 65535
+    protocol    = "udp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # outbound internet access
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
   }
 }


### PR DESCRIPTION
### What was wrong?

Two issue are fixed in this PR

- #81 security group is not specified.
- Since `topology.yml` is generated by a task, it can't be loaded as a global variable. The first run of the playbook would always fail and would work in the second run because `topology.yml` can be loaded then.

### How was it fixed?

- Add security group in Terraform
- Don't load`topology.yml` as a global variable, use `include_vars` to load it once generated.

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3391420/47255572-da2ee980-d4a5-11e8-8047-adbb16101699.png)

