### PR TITLE
Check `closer != nil` before `defer closer.Close()`

### DIFF
--- a/main.go
+++ b/main.go
@@ -153,9 +153,10 @@ func runServer(
 	}
 	tracerName := fmt.Sprintf("RPC Server@%v", rpcAddr)
 	tracer, closer, err := cfg.New(tracerName, jaegerconfig.Logger(jaeger.StdLogger))
-	defer closer.Close()
 	if err != nil {
 		logger.Debugf("Failed to create tracer, err: %v", err)
+	} else {
+		defer closer.Close()
 	}
 	opentracing.SetGlobalTracer(tracer)
 	// End of tracer setup


### PR DESCRIPTION
### What was wrong?
`SIGSEGV` occurs when `tracer` is not `New`ed successfully and therefore `closer == nil`

```
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x16135cd]

goroutine 1 [running]:
main.runServer(0x17d3d9d, 0x9, 0x2710, 0x0, 0x0, 0x0, 0x0, 0xc4200b3e10, 0xf, 0xc4200b3e30, ...)
        /go/src/github.com/ethresearch/sharding-p2p-poc/main.go:160 +0x67d
main.main()
        /go/src/github.com/ethresearch/sharding-p2p-poc/main.go:81 +0x5b0
```

### How was it fixed?
Move `defer closer.Close()` to the `else` block 


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://scontent.ftpe4-1.fna.fbcdn.net/v/t1.0-9/44307002_1086517311542669_4488283284366688256_o.jpg?_nc_cat=109&_nc_ht=scontent.ftpe4-1.fna&oh=95869163a871c5830134a1bd3ac00b05&oe=5C40831B)
