### PR TITLE
Fix nil event notifier

### DIFF
--- a/eventrpc.go
+++ b/eventrpc.go
@@ -10,17 +10,28 @@ import (
 	"google.golang.org/grpc"
 )
 
-var (
-	defulatEventRPCPort = 35566
-)
-
 type EventNotifier interface {
 	Receive(peerID peer.ID, msgType int, data []byte) ([]byte, error)
+}
+
+type mockEventNotifier struct {
 }
 
 type rpcEventNotifier struct {
 	client pbevent.EventClient
 	ctx    context.Context
+}
+
+func NewMockEventNotifier() *mockEventNotifier {
+	return &mockEventNotifier{}
+}
+
+func (notifier *mockEventNotifier) Receive(
+	peerID peer.ID,
+	msgType int,
+	data []byte) ([]byte, error) {
+	// Always return 1
+	return []byte{1}, nil
 }
 
 func NewRpcEventNotifier(ctx context.Context, rpcAddr string) (*rpcEventNotifier, error) {

--- a/eventrpc.go
+++ b/eventrpc.go
@@ -11,7 +11,7 @@ import (
 )
 
 type EventNotifier interface {
-	Receive(peerID peer.ID, msgType int, data []byte) ([]byte, error)
+	Receive(ctx context.Context, peerID peer.ID, msgType int, data []byte) ([]byte, error)
 }
 
 type mockEventNotifier struct {
@@ -19,7 +19,6 @@ type mockEventNotifier struct {
 
 type rpcEventNotifier struct {
 	client pbevent.EventClient
-	ctx    context.Context
 }
 
 func NewMockEventNotifier() *mockEventNotifier {
@@ -27,6 +26,7 @@ func NewMockEventNotifier() *mockEventNotifier {
 }
 
 func (notifier *mockEventNotifier) Receive(
+	ctx context.Context,
 	peerID peer.ID,
 	msgType int,
 	data []byte) ([]byte, error) {
@@ -43,12 +43,12 @@ func NewRpcEventNotifier(ctx context.Context, rpcAddr string) (*rpcEventNotifier
 	client := pbevent.NewEventClient(conn)
 	n := &rpcEventNotifier{
 		client: client,
-		ctx:    ctx,
 	}
 	return n, nil
 }
 
 func (notifier *rpcEventNotifier) Receive(
+	ctx context.Context,
 	peerID peer.ID,
 	msgType int,
 	data []byte) ([]byte, error) {
@@ -57,7 +57,7 @@ func (notifier *rpcEventNotifier) Receive(
 		MsgType: PBInt(msgType),
 		Data:    data,
 	}
-	res, err := notifier.client.Receive(notifier.ctx, req)
+	res, err := notifier.client.Receive(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/eventrpc.go
+++ b/eventrpc.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"time"
 
 	pbevent "github.com/ethresearch/sharding-p2p-poc/pb/event"
 	peer "github.com/libp2p/go-libp2p-peer"
@@ -23,9 +24,9 @@ type rpcEventNotifier struct {
 }
 
 func NewRpcEventNotifier(ctx context.Context, rpcAddr string) (*rpcEventNotifier, error) {
-	conn, err := grpc.Dial(rpcAddr, grpc.WithInsecure())
+	conn, err := grpc.Dial(rpcAddr, grpc.WithInsecure(), grpc.WithBlock(), grpc.WithTimeout(time.Second*1))
 	if err != nil {
-		logger.Errorf("failed to connect to the rpc server: %v", err)
+		logger.Errorf("Failed to connect to the event notifier rpc server: %v", err)
 		return nil, err
 	}
 	client := pbevent.NewEventClient(conn)

--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ func main() {
 	rpcPort := flag.Int("rpcport", defaultRPCPort, "RPC port listened by the RPC server")
 	notifierPort := flag.Int(
 		"notifierport",
-		defulatEventRPCPort,
+		0,
 		"notifier port listened by the event rpc server",
 	)
 	doBootstrapping := flag.Bool("bootstrap", false, "whether to do bootstrapping or not")
@@ -116,7 +116,17 @@ func runServer(
 	rpcAddr string,
 	notifierAddr string) {
 	ctx := context.Background()
-	eventNotifier, err := NewRpcEventNotifier(ctx, notifierAddr)
+	var eventNotifier EventNotifier
+	var err error
+	// Check if notifier port is 0 and use mock event notifier if so
+	if strings.Split(notifierAddr, ":")[1] == "0" {
+		eventNotifier = NewMockEventNotifier()
+	} else {
+		eventNotifier, err = NewRpcEventNotifier(ctx, notifierAddr)
+		if err != nil {
+			logger.Fatalf("Failed to connect RPC event notifier: %v", err)
+		}
+	}
 	var bootnodes = []pstore.PeerInfo{}
 	if bootnodesStr != "" {
 		bootnodes, err = convertPeers(strings.Split(bootnodesStr, ","))

--- a/main.go
+++ b/main.go
@@ -117,10 +117,6 @@ func runServer(
 	notifierAddr string) {
 	ctx := context.Background()
 	eventNotifier, err := NewRpcEventNotifier(ctx, notifierAddr)
-	if err != nil {
-		// TODO: don't use eventNotifier if it is not available
-		eventNotifier = nil
-	}
 	var bootnodes = []pstore.PeerInfo{}
 	if bootnodesStr != "" {
 		bootnodes, err = convertPeers(strings.Split(bootnodesStr, ","))
@@ -149,7 +145,7 @@ func runServer(
 			Param: 1,
 		},
 		Reporter: &jaegerconfig.ReporterConfig{
-			LogSpans: true,
+			LogSpans:           true,
 			LocalAgentHostPort: fmt.Sprintf("%v:%v", os.Getenv("JAEGER_AGENT_HOST"), os.Getenv("JAEGER_AGENT_PORT")),
 		},
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -705,6 +705,7 @@ func TestBroadcastCollationWithRPCEventNotifier(t *testing.T) {
 	}
 	waitForPubSubMeshBuilt()
 
+	nodes[0].eventNotifier = NewMockEventNotifier()
 	// setup 2 event server and notifier(stub), for node1 and node2 respectively
 	// event server and notifier for node1
 	eventRPCPort := 55667

--- a/main_test.go
+++ b/main_test.go
@@ -656,7 +656,7 @@ func TestEventRPCNotifier(t *testing.T) {
 		Blobs:   []byte("123"),
 	}
 	collationBytes := protoToBytes(t, collation)
-	isValidBytes, err := eventNotifier.Receive("", typeCollation, collationBytes)
+	isValidBytes, err := eventNotifier.Receive(ctx, "", typeCollation, collationBytes)
 	if err != nil {
 		t.Errorf("something wrong when calling `eventNotifier.Receive`: %v", err)
 	}
@@ -671,7 +671,7 @@ func TestEventRPCNotifier(t *testing.T) {
 		Hash:    "123",
 	}
 	reqBytes := protoToBytes(t, req)
-	respBytes, err := eventNotifier.Receive("", typeCollationRequest, reqBytes)
+	respBytes, err := eventNotifier.Receive(ctx, "", typeCollationRequest, reqBytes)
 	if err != nil {
 		t.Errorf("something wrong when calling `eventNotifier.Receive`: %v", err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -775,7 +775,6 @@ func TestRequestCollationWithRPCEventNotifier(t *testing.T) {
 	nodes := makeNodes(t, ctx, 2)
 	connectBarbell(t, ctx, nodes)
 
-	// case: without RPCEventNotifier set
 	shardID := ShardIDType(1)
 	period := 2
 	req := &pbmsg.CollationRequest{
@@ -784,17 +783,10 @@ func TestRequestCollationWithRPCEventNotifier(t *testing.T) {
 		Hash:    "",
 	}
 	reqBytes := protoToBytes(t, req)
-	_, err := nodes[0].generalRequest(ctx, nodes[1].ID(), typeCollationRequest, reqBytes)
-	// `err != nil` because nodes[1] hasn't set the eventNotifier, failing to handle the request
-	if err == nil {
-		t.Errorf(
-			"should be unable to unmarshal because nodes[1] should send invalid collation, due to the lack of an eventNotifier",
-		)
-	}
 
 	// case: with RPCEventNotifier set, db in the event server has the collation
 	notifierAddr := fmt.Sprintf("127.0.0.1:%v", 55669)
-	_, err = runEventServer(ctx, notifierAddr)
+	_, err := runEventServer(ctx, notifierAddr)
 	if err != nil {
 		t.Error("failed to run event server")
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -40,7 +40,7 @@ func makeTestingNode(
 	//		2. Avoid reuse of listeningPort in the entire test, to avoid `dial error`s
 	listeningPort := 20000 + nodeCount
 	nodeCount++
-	node, err := makeNode(ctx, defaultIP, listeningPort, number, nil, doBootstrapping, bootstrapPeers)
+	node, err := makeNode(ctx, defaultIP, listeningPort, number, NewMockEventNotifier(), doBootstrapping, bootstrapPeers)
 	if err != nil {
 		t.Error("Failed to create node")
 	}
@@ -705,7 +705,6 @@ func TestBroadcastCollationWithRPCEventNotifier(t *testing.T) {
 	}
 	waitForPubSubMeshBuilt()
 
-	nodes[0].eventNotifier = NewMockEventNotifier()
 	// setup 2 event server and notifier(stub), for node1 and node2 respectively
 	// event server and notifier for node1
 	eventRPCPort := 55667

--- a/requests.go
+++ b/requests.go
@@ -134,10 +134,6 @@ func (p *RequestProtocol) onGeneralRequest(s inet.Stream) {
 		)
 		return
 	}
-	if p.node.eventNotifier == nil {
-		logger.Error("onGeneralRequest: no eventNotifier set")
-		return
-	}
 	peerID := s.Conn().RemotePeer()
 	dataBytes, err := p.node.eventNotifier.Receive(peerID, int(req.MsgType), req.Data)
 	if err != nil {

--- a/requests.go
+++ b/requests.go
@@ -138,7 +138,7 @@ func (p *RequestProtocol) onGeneralRequest(s inet.Stream) {
 	dataBytes, err := p.node.eventNotifier.Receive(context.Background(), peerID, int(req.MsgType), req.Data)
 	if err != nil {
 		logger.Errorf(
-			"onGeneralRequest: failed to read proto message, reason=%v",
+			"onGeneralRequest: failed to receive response from event notifier, reason=%v",
 			err,
 		)
 		return

--- a/requests.go
+++ b/requests.go
@@ -135,7 +135,7 @@ func (p *RequestProtocol) onGeneralRequest(s inet.Stream) {
 		return
 	}
 	peerID := s.Conn().RemotePeer()
-	dataBytes, err := p.node.eventNotifier.Receive(peerID, int(req.MsgType), req.Data)
+	dataBytes, err := p.node.eventNotifier.Receive(context.Background(), peerID, int(req.MsgType), req.Data)
 	if err != nil {
 		logger.Errorf(
 			"onGeneralRequest: failed to read proto message, reason=%v",

--- a/shardmanager.go
+++ b/shardmanager.go
@@ -335,7 +335,7 @@ func (n *ShardManager) makeGeneralValidator(current_ctx context.Context, topic s
 			return false
 		}
 		// FIXME: if no eventNotifier, just skip the verification
-		if n.eventNotifier != (*rpcEventNotifier)(nil) {
+		if n.eventNotifier != (*rpcEventNotifier)(nil) && n.eventNotifier != nil {
 			validityBytes, err := n.eventNotifier.Receive(
 				msg.GetFrom(),
 				int(typedMessage.MsgType),

--- a/shardmanager.go
+++ b/shardmanager.go
@@ -336,6 +336,7 @@ func (n *ShardManager) makeGeneralValidator(current_ctx context.Context, topic s
 		}
 
 		validityBytes, err := n.eventNotifier.Receive(
+			spanctx,
 			msg.GetFrom(),
 			int(typedMessage.MsgType),
 			typedMessage.Data,

--- a/shardmanager.go
+++ b/shardmanager.go
@@ -335,7 +335,7 @@ func (n *ShardManager) makeGeneralValidator(current_ctx context.Context, topic s
 			return false
 		}
 		// FIXME: if no eventNotifier, just skip the verification
-		if n.eventNotifier != nil {
+		if n.eventNotifier != (*rpcEventNotifier)(nil) {
 			validityBytes, err := n.eventNotifier.Receive(
 				msg.GetFrom(),
 				int(typedMessage.MsgType),
@@ -343,12 +343,14 @@ func (n *ShardManager) makeGeneralValidator(current_ctx context.Context, topic s
 			)
 			if err != nil {
 				logger.FinishWithErr(spanctx, fmt.Errorf("Failed to receive response from event notifier, err: %v", err))
+				logger.Error(fmt.Errorf("Failed to receive response from event notifier, err: %v", err))
 				return false
 			}
 			// TODO: `retVal` from `n.eventNotifier.Receive` should be a bool.
 			//		 validityByte == b"\x00" means false, otherwise true.
 			if len(validityBytes) != 1 || validityBytes[0] == 0 {
 				logger.SetErr(spanctx, fmt.Errorf("Validation error, validation result: %v", validityBytes))
+				logger.Error(fmt.Errorf("Validation error, validation result: %v", validityBytes))
 				return false
 			}
 		}

--- a/shardmanager.go
+++ b/shardmanager.go
@@ -334,25 +334,23 @@ func (n *ShardManager) makeGeneralValidator(current_ctx context.Context, topic s
 			logger.FinishWithErr(spanctx, fmt.Errorf("Failed to parse message, err: %v", err))
 			return false
 		}
-		// FIXME: if no eventNotifier, just skip the verification
-		if n.eventNotifier != (*rpcEventNotifier)(nil) && n.eventNotifier != nil {
-			validityBytes, err := n.eventNotifier.Receive(
-				msg.GetFrom(),
-				int(typedMessage.MsgType),
-				typedMessage.Data,
-			)
-			if err != nil {
-				logger.FinishWithErr(spanctx, fmt.Errorf("Failed to receive response from event notifier, err: %v", err))
-				logger.Error(fmt.Errorf("Failed to receive response from event notifier, err: %v", err))
-				return false
-			}
-			// TODO: `retVal` from `n.eventNotifier.Receive` should be a bool.
-			//		 validityByte == b"\x00" means false, otherwise true.
-			if len(validityBytes) != 1 || validityBytes[0] == 0 {
-				logger.SetErr(spanctx, fmt.Errorf("Validation error, validation result: %v", validityBytes))
-				logger.Error(fmt.Errorf("Validation error, validation result: %v", validityBytes))
-				return false
-			}
+
+		validityBytes, err := n.eventNotifier.Receive(
+			msg.GetFrom(),
+			int(typedMessage.MsgType),
+			typedMessage.Data,
+		)
+		if err != nil {
+			logger.FinishWithErr(spanctx, fmt.Errorf("Failed to receive response from event notifier, err: %v", err))
+			logger.Error(fmt.Errorf("Failed to receive response from event notifier, err: %v", err))
+			return false
+		}
+		// TODO: `retVal` from `n.eventNotifier.Receive` should be a bool.
+		//		 validityByte == b"\x00" means false, otherwise true.
+		if len(validityBytes) != 1 || validityBytes[0] == 0 {
+			logger.SetErr(spanctx, fmt.Errorf("Validation error, validation result: %v", validityBytes))
+			logger.Error(fmt.Errorf("Validation error, validation result: %v", validityBytes))
+			return false
 		}
 		return true
 	}


### PR DESCRIPTION
### What was wrong?
`eventnotifier` was set to `nil` if there was no event notifier server. However it was an interface with its value being `nil`, not a `nil` interface. So the comparison `n.eventnotifier != nil` will always return `true`.


### How was it fixed?
Compare `n.eventnotifier` against typed `nil`


#### Cute Animal Picture

![](https://www.maxpixel.net/static/photo/2x/Cat-Kitty-Cute-Pets-1796843.jpg)
pic credit: [maxpixel](https://www.maxpixel.net/Cute-Kitty-Pets-Cat-1796843)