### PR TITLE
Fix nil tracer

### DIFF
--- a/main.go
+++ b/main.go
@@ -179,9 +179,9 @@ func runServer(
 	if err != nil {
 		logger.Debugf("Failed to create tracer, err: %v", err)
 	} else {
+		opentracing.SetGlobalTracer(tracer)
 		defer closer.Close()
 	}
-	opentracing.SetGlobalTracer(tracer)
 	// End of tracer setup
 
 	logger.Infof(

--- a/main.go
+++ b/main.go
@@ -155,6 +155,10 @@ func runServer(
 	}
 
 	// Set up Opentracing and Jaeger tracer
+	var localAgentHostPort string
+	if (os.Getenv("JAEGER_AGENT_HOST") != "") && (os.Getenv("JAEGER_AGENT_PORT") != "") {
+		localAgentHostPort = fmt.Sprintf("%v:%v", os.Getenv("JAEGER_AGENT_HOST"), os.Getenv("JAEGER_AGENT_PORT"))
+	}
 	cfg := &jaegerconfig.Configuration{
 		Sampler: &jaegerconfig.SamplerConfig{
 			Type:  "const",
@@ -162,7 +166,7 @@ func runServer(
 		},
 		Reporter: &jaegerconfig.ReporterConfig{
 			LogSpans:           true,
-			LocalAgentHostPort: fmt.Sprintf("%v:%v", os.Getenv("JAEGER_AGENT_HOST"), os.Getenv("JAEGER_AGENT_PORT")),
+			LocalAgentHostPort: localAgentHostPort,
 		},
 	}
 	var tracerName string


### PR DESCRIPTION
### What was wrong?
Tracer config takes in ENV variables `JAEGER_AGENT_HOST` and `JAEGER_AGENT_PORT` but it was presumed that these ENV variables will be passed in. And hence tracer will fail to initialize if the variables are not passed in.
Secondly, global tracer is set even if tracer fails to initialize.


#### Cute Animal Picture

![](https://cdn.pixabay.com/photo/2017/09/25/13/12/dog-2785074_1280.jpg)