### PR TITLE
Testing script for Whiteblock

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -433,11 +433,11 @@ func TestListenShardConnectingPeers(t *testing.T) {
 
 	// 0 <-> 1 <-> 2
 	if err := nodes[0].ListenShard(ctx, 0); err != nil {
-		t.Errorf("Failed to listen to shard 0")
+		t.Errorf("Failed to listen to shard 0, err=%v", err)
 	}
 
 	if err := nodes[2].ListenShard(ctx, 42); err != nil {
-		t.Errorf("Failed to listen to shard 42")
+		t.Errorf("Failed to listen to shard 42, err=%v", err)
 	}
 	// wait for peer to receive shard subscription update
 	time.Sleep(time.Millisecond * 100)
@@ -447,12 +447,15 @@ func TestListenShardConnectingPeers(t *testing.T) {
 		t.Error("Node 0 shouldn't have connection with node 2")
 	}
 
+	// test `connectShardNodes`
 	if err := nodes[0].ListenShard(ctx, 42); err != nil {
-		t.Errorf("Failed to listen to shard 42")
+		t.Errorf("Failed to listen to shard 42, err=%v", err)
 	}
 	// wait for peer to receive shard subscription update
 	time.Sleep(time.Millisecond * 100)
-
+	if err := nodes[0].connectShardNodes(ctx, 42); err != nil {
+		t.Errorf("Failed to connect to shard Nodes, err=%v", err)
+	}
 	connWithNode2 = nodes[0].Network().ConnsToPeer(nodes[2].ID())
 	if len(connWithNode2) == 0 {
 		t.Error("Node 0 should have connected to node 2 after listening to shard 42")

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -98,6 +98,7 @@ func (s *server) AddPeer(
 
 	// Tag the span with peer info
 	logger.SetTag(spanctx, "Added peer", fmt.Sprintf("%v:%v", req.Ip, req.Port))
+	logger.Debug("rpcserver:AddPeer: finished")
 	return &pbrpc.RPCPlainResponse{}, nil
 }
 
@@ -125,6 +126,7 @@ func (s *server) SubscribeShard(
 	}
 	// Tag the span with shardIDs which are successfully subscribed to
 	logger.SetTag(spanctx, "ShardIDs", fmt.Sprintf("%v", subscribedShardID))
+	logger.Debug("rpcserver:SubscribeShard: finished")
 	return &pbrpc.RPCPlainResponse{}, nil
 }
 
@@ -152,6 +154,7 @@ func (s *server) UnsubscribeShard(
 	}
 	// Tag the span with shardIDs which are successfully unsubscribed from
 	logger.SetTag(spanctx, "ShardIDs", fmt.Sprintf("shard %v", unsubscribedShardID))
+	logger.Debug("rpcserver:UnsubscribeShard: finished")
 	return &pbrpc.RPCPlainResponse{}, nil
 }
 
@@ -190,14 +193,20 @@ func (s *server) BroadcastCollation(
 	}
 	defer logger.Finish(spanctx)
 
-	logger.Debugf("rpcserver:BroadcastCollationRequest: receive=%v", req)
 	shardID := req.ShardID
 	numCollations := int(req.Number)
-	timeInMs := req.Period
 	sizeInBytes := req.Size
 	if sizeInBytes > 100 {
 		sizeInBytes -= 100
 	}
+	timeInMs := req.Period
+	logger.Debugf(
+		"rpcserver:BroadcastCollation: broadcasting: shardID=%v, numCollations=%v, sizeInBytes=%v, timeInMs=%v",
+		shardID,
+		numCollations,
+		sizeInBytes,
+		timeInMs,
+	)
 	for i := 0; i < numCollations; i++ {
 		// control the speed of sending collations
 		time.Sleep(time.Millisecond * time.Duration(timeInMs))
@@ -220,6 +229,7 @@ func (s *server) BroadcastCollation(
 	logger.SetTag(spanctx, "shardID", req.ShardID)
 	logger.SetTag(spanctx, "numCollations", numCollations)
 	logger.SetTag(spanctx, "sizeInBytes", sizeInBytes)
+	logger.Debug("rpcserver:BroadcastCollation: finished")
 	return &pbrpc.RPCPlainResponse{}, nil
 }
 
@@ -249,6 +259,7 @@ func (s *server) SendCollation(
 	logger.SetTag(spanctx, "Shard", collation.ShardID)
 	logger.SetTag(spanctx, "Period of collation", collation.Period)
 	logger.SetTag(spanctx, "Blobs of collation", collation.Blobs)
+	logger.Debug("rpcserver:SendCollation: finished")
 	return &pbrpc.RPCPlainResponse{}, nil
 }
 
@@ -269,6 +280,7 @@ func (s *server) StopServer(
 		logger.Info("Closing RPC server by rpc call...")
 		s.rpcServer.Stop()
 	}()
+	logger.Debug("rpcserver:StopServer: finished")
 	return &pbrpc.RPCPlainResponse{}, nil
 }
 
@@ -323,6 +335,7 @@ func (s *server) Send(ctx context.Context, req *pbrpc.SendRequest) (*pbrpc.SendR
 	if err != nil {
 		return nil, fmt.Errorf("failed to make request to peer %v", peerID)
 	}
+	logger.Debug("rpcserver:Send: finished")
 	return &pbrpc.SendResponse{
 		Data: dataBytes,
 	}, nil
@@ -387,6 +400,7 @@ func (s *server) RemovePeer(
 	}
 
 	// TODO: consider the record in Peerstore
+	logger.Debug("rpcserver:RemovePeer: finished")
 	return &pbrpc.RPCPlainResponse{}, nil
 }
 

--- a/shardmanager.go
+++ b/shardmanager.go
@@ -147,11 +147,11 @@ func (n *ShardManager) ListenShard(ctx context.Context, shardID ShardIDType) err
 		return err
 	}
 
-	// TODO: should set a critiria: if we have enough peers in the shard, don't connect shard nodes
-	if err := n.connectShardNodes(spanctx, shardID); err != nil {
-		logger.SetErr(spanctx, fmt.Errorf("Failed to connect to nodes in shard %v", shardID))
-		logger.Errorf("Failed to connect to nodes in shard %v", shardID)
-	}
+	// // TODO: should set a critiria: if we have enough peers in the shard, don't connect shard nodes
+	// if err := n.connectShardNodes(spanctx, shardID); err != nil {
+	// 	logger.SetErr(spanctx, fmt.Errorf("Failed to connect to nodes in shard %v", shardID))
+	// 	logger.Errorf("Failed to connect to nodes in shard %v", shardID)
+	// }
 
 	// shardCollations protocol
 	if err := n.SubscribeCollation(spanctx, shardID); err != nil {

--- a/shardmanager.go
+++ b/shardmanager.go
@@ -147,12 +147,6 @@ func (n *ShardManager) ListenShard(ctx context.Context, shardID ShardIDType) err
 		return err
 	}
 
-	// // TODO: should set a critiria: if we have enough peers in the shard, don't connect shard nodes
-	// if err := n.connectShardNodes(spanctx, shardID); err != nil {
-	// 	logger.SetErr(spanctx, fmt.Errorf("Failed to connect to nodes in shard %v", shardID))
-	// 	logger.Errorf("Failed to connect to nodes in shard %v", shardID)
-	// }
-
 	// shardCollations protocol
 	if err := n.SubscribeCollation(spanctx, shardID); err != nil {
 		logger.FinishWithErr(spanctx, fmt.Errorf("Failed to subscribe to collation in shard %v", shardID))

--- a/test/test_one_shard.py
+++ b/test/test_one_shard.py
@@ -82,7 +82,7 @@ class Node:
             bootnodes_cmd = "-bootstrap -bootnodes={}".format(
             ",".join(bootnodes),
         )
-        cmd = "docker run -d --name {} -p {}:10000 -p {}:13000 ethereum/sharding-p2p:dev sh -c \"./sharding-p2p-poc -loglevel=DEBUG -ip=0.0.0.0 -seed={} {}\"".format(
+        cmd = "docker run -d --name {} -p {}:10000 -p {}:13000 ethereum/sharding-p2p:latest sh -c \"./sharding-p2p-poc -loglevel=DEBUG -ip=0.0.0.0 -seed={} {}\"".format(
             self.name,
             self.port,
             self.rpc_port,
@@ -237,6 +237,13 @@ if __name__ == "__main__":
     for node in bootnodes:
         node.subscribe_shard([0])
     bootnodes[0].broadcast_collation(0, 10, 100, 100)
+    print("Waiting for messages broadcasted...", end='')
+    time.sleep(2)
+    print("done")
+    log = bootnodes[-1].grep_log('Validating the received message')
+    print(log)
+    sys.exit(1)
+
 
     bootnodes_multiaddr = [node.multiaddr for node in bootnodes]
     print("Spinning up {} nodes...".format(num_normal_nodes), end='')
@@ -248,3 +255,4 @@ if __name__ == "__main__":
     print("done")
 
     print(nodes[-1].list_peer())
+    # print(nodes)

--- a/test/test_one_shard.py
+++ b/test/test_one_shard.py
@@ -1,0 +1,477 @@
+#!/usr/bin/env python
+
+import re
+import subprocess
+import sys
+import os
+import time
+
+# --i <image>
+# --n <number of nodes>
+# --I <interface> eno4
+# example:
+# os.system("./umba --i sharding --I eno4 --n 20")
+# os.system("docker exec -it whiteblock-node0 -port=8080")
+# ip eample: 10.1.0.2 would be whiteblock-node0
+# 10.1.0.6 would be whiteblock-node1 ++
+# just add the flags and commands that are needed
+# we will handle logic of collecting data and configuring umba
+
+#TEST SERIES A
+#LATENCY
+
+RPC_PORT_BASE = 13000
+PORT_BASE = 10000
+N = 100
+
+
+def get_docker_host_ip():
+    sysname = os.uname().sysname
+    if sysname != 'Darwin' and sysname != 'Linux':
+        raise ValueError(
+            "Failed to get ip in platforms other than Linux and macOS: {}".format(sysname)
+        )
+    cmd = 'ifconfig | grep -E "([0-9]{1,3}\\.){3}[0-9]{1,3}" | grep -v 127.0.0.1 | awk \'{ print $2 }\' | cut -f2 -d: | head -n1'
+    res = subprocess.run(cmd, shell=True, check=True, stdout=subprocess.PIPE, encoding='utf-8')
+    return res.stdout.rstrip()
+
+
+class Node:
+
+    ip = None
+    port = None
+    rpc_port = None
+    peer_id = None
+    seed = None
+
+    def __init__(self, ip, port, rpc_port, seed):
+        self.ip = ip
+        self.port = port
+        self.rpc_port = rpc_port
+        self.seed = seed
+
+    def __repr__(self):
+        return "<Node seed={} peer_id={}>".format(
+            self.seed,
+            None if self.peer_id is None else self.peer_id[2:8],
+        )
+
+    @property
+    def name(self):
+        return f"whiteblock-node{self.seed}"
+
+    @property
+    def multiaddr(self):
+        return f"/ip4/{self.ip}/tcp/{self.port}/ipfs/{self.peer_id}"
+
+    def close(self):
+        subprocess.run(f"docker kill {self.name}", shell=True)
+        subprocess.run(f"docker rm -f {self.name}", shell=True)
+
+    def run_docker(self, bootnodes=None):
+        """`bootnodes` should be a list of string. Each string should be a multiaddr.
+        """
+        self.close()
+        cmd = "docker run -d --name {} -p {}:10000 -p {}:13000 ethereum/sharding-p2p:dev sh -c \"./sharding-p2p-poc -loglevel=DEBUG -ip=0.0.0.0 -seed={}\"".format(
+            self.name,
+            self.port,
+            self.rpc_port,
+            self.seed,
+        )
+        if bootnodes is not None:
+            cmd += " -bootnodes={}".format(
+                ",".join(bootnodes),
+            )
+        subprocess.run(cmd, shell=True, check=True)
+
+    def cli(self, cmd, **kwargs):
+        cmd_list = cmd.split(' ')
+        cmd_quoted_param_list = ["'{}'".format(i) for i in cmd_list]
+        cmd_quoted_param_str = " ".join(cmd_quoted_param_list)
+        return subprocess.run(
+            [
+                "docker",
+                "exec",
+                "-t",
+                self.name,
+                "sh",
+                "-c",
+                "./sharding-p2p-poc '-client' {}".format(cmd_quoted_param_str),
+            ],
+            stdout=subprocess.PIPE,
+            encoding='utf-8',
+            **kwargs,
+        )
+
+    def cli_safe(self, cmd):
+        res = self.cli(cmd, check=True)
+        return res.stdout.rstrip()
+
+    def add_peer(self, ip, port, seed):
+        return self.cli_safe("addpeer {} {} {}".format(ip, port, seed))
+
+    def remove_peer(self, peer_id):
+        return self.cli_safe("removepeer {}".format(peer_id))
+
+    def list_peer(self):
+        return self.cli_safe("listpeer")
+
+    def list_topic_peer(self, topics):
+        return self.cli_safe("listtopic {}".format(' '.join(topics)))
+
+    def subscribe_shard(self, shard_ids):
+        return self.cli_safe("subshard {}".format(' '.join(map(str, shard_ids))))
+
+    def unsubscribe_shard(self, shard_ids):
+        return self.cli_safe("unsubshard {}".format(' '.join(map(str, shard_ids))))
+
+    def get_subscribed_shard(self):
+        return self.cli_safe("getsubshard")
+
+    def broadcast_collation(self, shard_id, num_collations, collation_size, collation_time):
+        return self.cli_safe("broadcastcollation {} {} {} {}".format(
+            shard_id,
+            num_collations,
+            collation_size,
+            collation_time
+        ))
+
+    def stop(self):
+        return self.cli_safe("stop")
+
+    def grep_log(self, pattern):
+        res = subprocess.run(
+            [
+                "docker logs {} 2>&1 | grep '{}'".format(self.name, pattern),
+            ],
+            shell=True,
+            stdout=subprocess.PIPE,
+            encoding='utf-8',
+        )
+        return res.stdout.rstrip()
+
+    def set_peer_id(self):
+        grep_res = self.grep_log('Node is listening')
+        match = re.search('peerID=([a-zA-Z0-9]+) ', grep_res)
+        if match is None:
+            raise ValueError("failed to grep the peer_id from docker logs")
+        self.peer_id = match[1]
+
+
+def make_node(seed):
+    n = Node(
+        get_docker_host_ip(),
+        seed + PORT_BASE,
+        seed + RPC_PORT_BASE,
+        seed,
+    )
+    n.run_docker()
+    return n
+
+
+def make_local_nodes(num):
+    nodes = []
+    for i in range(num):
+        nodes.append(make_node(i))
+    time.sleep(2)
+    for node in nodes:
+        node.set_peer_id()
+    return nodes
+
+
+def connect_barbell(nodes):
+    for i in range(len(nodes) - 1):
+        nodes[i].add_peer(
+            nodes[i + 1].ip,
+            nodes[i + 1].port,
+            nodes[i + 1].seed,
+        )
+
+
+if __name__ == "__main__":
+    nodes = make_local_nodes(3)
+    connect_barbell(nodes)
+    print(nodes[2].list_peer())
+
+    import sys
+    sys.exit(1)
+
+    #A1
+    #0ms
+    print("A1 Start")
+    os.chdir("/home/appo/umba")
+    os.system("./umba -i sharding -n 22 --servers alpha,bravo,charlie,echo,foxtrot --verbose --bp 22 --clients 24 --number-of-tx 4000") 
+    # os.system("docker exec -it whiteblock-node0 -port=8080")
+
+    print("A1 Complete")
+    print("Going To Sleep")
+    time.sleep(1200)
+
+    print("Parsing & Saving Data")
+
+    os.system("")
+
+    os.system("~/rpc/rpc --ip 10.2.0.2 -S $(cat block_num.txt) -x A1")
+
+    print("Shutting Down")
+
+    #A2
+    #50ms 
+    print("A2 Start")
+    os.chdir("/home/appo/umba")
+    os.system("./umba -i sharding -n 22 --servers alpha,bravo,charlie,echo,foxtrot --verbose --bp 22 --clients 24 --number-of-tx 4000 --emulate --loss 0 --latency 12") 
+
+
+    print("A2 Complete")
+
+    print("Going To Sleep")
+    time.sleep(1800)
+
+    print("Parsing & Saving Data")
+    os.system("~/rpc/rpc --ip 10.2.0.2 -S $(cat block_num.txt) -x A2")
+
+    print("Shutting Down")
+
+    #A3
+    #100ms
+    print("A3 Start")
+    os.chdir("/home/appo/umba")
+    os.system("./umba -i sharding -n 22 --servers alpha,bravo,charlie,echo,foxtrot --verbose --bp 22 --clients 24 --number-of-tx 4000 --emulate --loss 0 --latency 25") 
+
+    print("A3 Complete")
+
+    print("Going To Sleep")
+    time.sleep(1800)
+
+    print("Parsing & Saving Data")
+    os.system("~/rpc/rpc --ip 10.2.0.2 -S $(cat block_num.txt) -x A3")
+
+    print("Shutting Down")
+
+    #TEST SERIES B
+    #TRANSACTION VOLUME
+
+    #B1
+    #8000 tx
+    print("B1 Start")
+    os.chdir("/home/appo/umba")
+    os.system("./umba -i sharding -n 22 --servers alpha,bravo,charlie,echo,foxtrot --verbose --bp 22 --clients 24 --number-of-tx 8000") 
+    print("B1 Complete")
+
+    print("Going To Sleep")
+    time.sleep(1800)
+
+    print("Parsing & Saving Data")
+    os.system("~/rpc/rpc --ip 10.2.0.2 -S $(cat block_num.txt) -x B1")
+
+    #B2
+    #16000 tx
+    print("B2 Start")
+    os.chdir("/home/appo/umba")
+    os.system("./umba -i sharding -n 22 --servers alpha,bravo,charlie,echo,foxtrot --verbose --bp 22 --clients 24 --number-of-tx 16000") 
+    print("B2 Complete")
+
+    print("Going To Sleep")
+    time.sleep(1800)
+
+    print("Parsing & Saving Data")
+    os.system("~/rpc/rpc --ip 10.2.0.2 -S $(cat block_num.txt) -x B2")
+    print("Shutting Down")
+
+    #B3
+    #20000tx
+    print("B3 Start")
+    os.chdir("/home/appo/umba")
+    os.system("./umba -i sharding -n 22 --servers alpha,bravo,charlie,echo,foxtrot --verbose --bp 22 --clients 24 --number-of-tx 20000") 
+    print("B3 Complete")
+
+    print("Going To Sleep")
+    time.sleep(1800)
+
+    print("Parsing & Saving Data")
+    os.system("~/rpc/rpc --ip 10.2.0.2 -S $(cat block_num.txt) -x B3")
+    print("Shutting Down")
+
+    #TEST SERIES C
+    #TRANSACTION SIZE
+
+    #C1
+    #500B
+    print("C1 Start")
+    os.chdir("/home/appo/umba")
+    os.system("./umba -i sharding -n 22 --servers alpha,bravo,charlie,echo,foxtrot --verbose --bp 22 --clients 24 --number-of-tx 4000 --tx-size 259") 
+    print("C1 Complete")
+
+    print("Going To Sleep")
+    time.sleep(1200)
+
+    print("Parsing & Saving Data")
+    os.system("~/rpc/rpc --ip 10.2.0.2 -S $(cat block_num.txt) -x C1")
+    print("Shutting Down")
+
+    #C2
+    #1000B
+    print("C2 Start")
+    os.chdir("/home/appo/umba")
+    os.system("./umba -i sharding -n 22 --servers alpha,bravo,charlie,echo,foxtrot --verbose --bp 22 --clients 24 --number-of-tx 4000 --tx-size 344") 
+    print("C2 Complete")
+
+    print("Going To Sleep")
+    time.sleep(1200)
+
+    print("Parsing & Saving Data")
+    os.system("~/rpc/rpc --ip 10.2.0.2 -S $(cat block_num.txt) -x C2")
+    print("Shutting Down")
+
+    #C3
+    #2000B
+    print("C3 Start")
+    os.chdir("/home/appo/umba")
+    os.system("./umba -i sharding -n 22 --servers alpha,bravo,charlie,echo,foxtrot --verbose --bp 22 --clients 24 --number-of-tx 4000 --tx-size 429") 
+    print("C3 Complete")
+
+    print("Going To Sleep")
+    time.sleep(1200)
+
+    print("Parsing & Saving Data")
+    os.system("~/rpc/rpc --ip 10.2.0.2 -S $(cat block_num.txt) -x C3")
+    print("Shutting Down")
+
+    #TEST SERIES D
+    #HIGHER LATENCY
+
+    #D1
+    #200ms
+    print("D1 Start")
+    os.chdir("/home/appo/umba")
+    os.system("./umba -i sharding -n 22 --servers alpha,bravo,charlie,echo,foxtrot --verbose --bp 22 --clients 24 --number-of-tx 4000 --emulate --latency 50") 
+    print("D1 Complete")
+
+    time.sleep(1800)
+    os.system("~/rpc/rpc --ip 10.2.0.2 -S $(cat block_num.txt) -x D1")
+
+    #D2
+    #300ms
+    print("D2")
+    os.chdir("/home/appo/umba")
+    os.system("./umba -i sharding -n 22 --servers alpha,bravo,charlie,echo,foxtrot --verbose --bp 22 --clients 24 --number-of-tx 4000 --emulate --latency 75") 
+
+
+    time.sleep(1800)
+    os.system("~/rpc/rpc --ip 10.2.0.2 -S $(cat block_num.txt) -x D2")
+
+
+    #D3
+    #400ms
+    print("D3")
+    os.chdir("/home/appo/umba")
+    os.system("./umba -i sharding -n 22  --servers alpha,bravo,charlie,echo,foxtrot --verbose --bp 22 --clients 24 --number-of-tx 4000 --emulate --loss 0 --latency 100") 
+
+
+    time.sleep(1800)
+    os.system("~/rpc/rpc --ip 10.2.0.2 -S $(cat block_num.txt) -x D3")
+
+
+    #TEST SERIES E
+    #PACKET LOSS
+
+    #E1
+    #0.01%
+    print("E1")
+    os.chdir("/home/appo/umba")
+    os.system("./umba -i sharding -n 22  --servers alpha,bravo,charlie,echo,foxtrot --verbose --bp 22 --clients 24 --number-of-tx 4000 --emulate --loss 0.0025 --latency 0") 
+
+    time.sleep(1800)
+    os.system("~/rpc/rpc --ip 10.2.0.2 -S $(cat block_num.txt) -x E1")
+
+
+    #E2
+    #0.1%
+    print("E2")
+    os.chdir("/home/appo/umba")
+    os.system("./umba -i sharding -n 22  --servers alpha,bravo,charlie,echo,foxtrot --verbose --bp 22 --clients 24 --number-of-tx 4000 --emulate --loss 0.025 --latency 0") 
+
+
+    time.sleep(1800)
+    os.system("~/rpc/rpc --ip 10.2.0.2 -S $(cat block_num.txt) -x E2")
+
+
+    #E3
+    #1%
+    print("E3")
+    os.chdir("/home/appo/umba")
+    os.system("./umba -i sharding -n 22  --servers alpha,bravo,charlie,echo,foxtrot --verbose --bp 22 --clients 24 --number-of-tx 4000 --emulate --loss 0.25 --latency 0") 
+
+
+    time.sleep(1800)
+    os.system("~/rpc/rpc --ip 10.2.0.2 -S $(cat block_num.txt) -x E3")
+
+    #TEST SERIES F
+    #NUMBER OF BLOCK PRODUCERS
+
+    #F1
+    #3BP
+    print("F1")
+    os.chdir("/home/appo/umba")
+    os.system("./umba -i sharding -n 4  --servers alpha,bravo,charlie,echo,foxtrot --verbose --bp 4 --clients 24 --number-of-tx 4000") 
+
+    time.sleep(1200)
+    os.system("~/rpc/rpc --ip 10.2.0.2 -S $(cat block_num.txt) -x F1")
+
+    #F2
+    #11BP
+    print("F2")
+    os.chdir("/home/appo/umba")
+    os.system("./umba -i sharding -n 12  --servers alpha,bravo,charlie,echo,foxtrot --verbose --bp 12 --clients 24 --number-of-tx 4000") 
+
+    time.sleep(1200)
+    os.system("~/rpc/rpc --ip 10.2.0.2 -S $(cat block_num.txt) -x F2")
+
+    #F3
+    #15BP
+    print("F3")
+    os.chdir("/home/appo/umba")
+    os.system("./umba -i sharding -n 16  --servers alpha,bravo,charlie,echo,foxtrot --verbose --bp 16 --clients 24 --number-of-tx 4000") 
+
+    time.sleep(1200)
+    os.system("~/rpc/rpc --ip 10.2.0.2 -S $(cat block_num.txt) -x F3")
+
+    #TEST SERIES G
+    #HIGHER NUMBER OF CLIENTS
+
+    #G1
+    #100
+    print("G1")
+    os.chdir("/home/appo/umba")
+    os.system("./umba -i sharding -n 22  --servers alpha,bravo,charlie,echo,foxtrot --verbose --bp 22 --clients 100 --number-of-tx 4000") 
+
+    time.sleep(1200)
+    os.system("~/rpc/rpc --ip 10.2.0.2 -S $(cat block_num.txt) -x G1")
+
+    #G2
+    #200
+    print("G2")
+    os.chdir("/home/appo/umba")
+    os.system("./umba -i sharding -n 22  --servers alpha,bravo,charlie,echo,foxtrot --verbose --bp 22 --clients 200 --number-of-tx 4000") 
+
+    time.sleep(1200)
+    os.system("~/rpc/rpc --ip 10.2.0.2 -S $(cat block_num.txt) -x G2")
+
+    #G3
+    #300
+    print("G3")
+    os.chdir("/home/appo/umba")
+    os.system("./umba -i sharding -n 22  --servers alpha,bravo,charlie,echo,foxtrot --verbose --bp 22 --clients 300 --number-of-tx 4000") 
+
+    time.sleep(1200)
+    os.system("~/rpc/rpc --ip 10.2.0.2 -S $(cat block_num.txt) -x G3")
+
+    #TEST SERIES H
+    #H1 DONKEY KONG
+    print("H1 Start")
+    os.chdir("/home/appo/umba")
+    os.system("./umba -i sharding -n 22  --servers alpha,bravo,charlie,echo,foxtrot --verbose --bp 22 --clients 3000 --number-of-tx 4000 --emulate --loss 0.5 --latency 25") 
+
+
+    time.sleep(7200)
+    os.system("~/rpc/rpc --ip 10.2.0.2 -S $(cat block_num.txt) -x E3")

--- a/test/test_one_shard.py
+++ b/test/test_one_shard.py
@@ -12,6 +12,13 @@ import threading
 import os
 import time
 
+from utils import (
+    connect_barbell,
+    ensure_barbell_connections,
+    kill_nodes,
+    make_local_nodes,
+)
+
 # --i <image>
 # --n <number of nodes>
 # --I <interface> eno4
@@ -26,251 +33,50 @@ import time
 #TEST SERIES A
 #LATENCY
 
-RPC_PORT_BASE = 13000
-PORT_BASE = 10000
 
+def test_time_broadcasting_data_single_shard():
+    num_nodes = 3
+    num_collations = 20
+    collation_size = 1000000  # 1MB
+    collation_time = 50  # broadcast 1 collation every 50 milliseconds
 
-logger = logging.getLogger("test_one_shard")
+    print("Spinning up {} nodes...".format(num_nodes), end='')
+    nodes = make_local_nodes(0, num_nodes)
+    print("done")
+    print("Connecting nodes...", end='')
+    connect_barbell(nodes)
+    print("done")
+    print("Checking the connections...", end='')
+    ensure_barbell_connections(nodes)
+    print("done")
 
-
-def get_docker_host_ip():
-    sysname = os.uname().sysname
-    if sysname != 'Darwin' and sysname != 'Linux':
-        raise ValueError(
-            "Failed to get ip in platforms other than Linux and macOS: {}".format(sysname)
-        )
-    cmd = 'ifconfig | grep -E "([0-9]{1,3}\\.){3}[0-9]{1,3}" | grep -v 127.0.0.1 | awk \'{ print $2 }\' | cut -f2 -d: | head -n1'
-    res = subprocess.run(cmd, shell=True, check=True, stdout=subprocess.PIPE, encoding='utf-8')
-    return res.stdout.rstrip()
-
-
-class Node:
-
-    ip = None
-    port = None
-    rpc_port = None
-    peer_id = None
-    seed = None
-
-    def __init__(self, ip, port, rpc_port, seed):
-        self.ip = ip
-        self.port = port
-        self.rpc_port = rpc_port
-        self.seed = seed
-
-    def __repr__(self):
-        return "<Node seed={} peer_id={}>".format(
-            self.seed,
-            None if self.peer_id is None else self.peer_id[2:8],
-        )
-
-    @property
-    def name(self):
-        return f"whiteblock-node{self.seed}"
-
-    @property
-    def multiaddr(self):
-        return f"/ip4/{self.ip}/tcp/{self.port}/ipfs/{self.peer_id}"
-
-    def close(self):
-        subprocess.run(f"docker kill {self.name}", shell=True, stdout=subprocess.PIPE)
-        subprocess.run(f"docker rm -f {self.name}", shell=True, stdout=subprocess.PIPE)
-
-    def run(self, bootnodes=None):
-        """`bootnodes` should be a list of string. Each string should be a multiaddr.
-        """
-        self.close()
-        bootnodes_cmd = ""
-        if bootnodes is not None:
-            bootnodes_cmd = "-bootstrap -bootnodes={}".format(
-            ",".join(bootnodes),
-        )
-        cmd = "docker run -d --name {} -p {}:10000 -p {}:13000 ethresearch/sharding-p2p:dev sh -c \"./sharding-p2p-poc -loglevel=DEBUG -ip=0.0.0.0 -seed={} {}\"".format(
-            self.name,
-            self.port,
-            self.rpc_port,
-            self.seed,
-            bootnodes_cmd,
-        )
-        subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, check=True)
-
-    def cli(self, cmd, **kwargs):
-        cmd_list = cmd.split(' ')
-        cmd_quoted_param_list = ["'{}'".format(i) for i in cmd_list]
-        cmd_quoted_param_str = " ".join(cmd_quoted_param_list)
-        return subprocess.run(
-            [
-                "docker",
-                "exec",
-                "-t",
-                self.name,
-                "sh",
-                "-c",
-                "./sharding-p2p-poc '-client' {}".format(cmd_quoted_param_str),
-            ],
-            stdout=subprocess.PIPE,
-            encoding='utf-8',
-            **kwargs,
-        )
-
-    def cli_safe(self, cmd):
-        res = self.cli(cmd, check=True).stdout.rstrip()
-        # assume CLIs only reply data in JSON
-        if res != '':
-            res = json.loads(res)
-        return res
-
-    def add_peer(self, node):
-        self.cli_safe("addpeer {} {} {}".format(node.ip, node.port, node.seed))
-
-    def remove_peer(self, peer_id):
-        self.cli_safe("removepeer {}".format(peer_id))
-
-    def list_peer(self):
-        return self.cli_safe("listpeer")
-
-    def list_topic_peer(self, topics):
-        return self.cli_safe("listtopic {}".format(' '.join(topics)))
-
-    def subscribe_shard(self, shard_ids):
-        return self.cli_safe("subshard {}".format(' '.join(map(str, shard_ids))))
-
-    def unsubscribe_shard(self, shard_ids):
-        return self.cli_safe("unsubshard {}".format(' '.join(map(str, shard_ids))))
-
-    def get_subscribed_shard(self):
-        return self.cli_safe("getsubshard")
-
-    def broadcast_collation(self, shard_id, num_collations, collation_size, collation_time):
-        return self.cli_safe("broadcastcollation {} {} {} {}".format(
-            shard_id,
-            num_collations,
-            collation_size,
-            collation_time,
-        ))
-
-    def stop(self):
-        return self.cli_safe("stop")
-
-    def grep_log(self, pattern):
-        res = subprocess.run(
-            [
-                "docker logs {} 2>&1 | grep '{}'".format(
-                    self.name,
-                    pattern,
-                ),
-            ],
-            shell=True,
-            stdout=subprocess.PIPE,
-            encoding='utf-8',
-        )
-        return res.stdout.rstrip()
-
-    def set_peer_id(self):
-        grep_res = self.grep_log('Node is listening')
-        match = re.search(r'peerID=([a-zA-Z0-9]+) ', grep_res)
-        if match is None:
-            raise ValueError("failed to grep the peer_id from docker logs")
-        self.peer_id = match[1]
-
-    def get_log_time(self, pattern, kth=0):
-        logs = self.grep_log(pattern)
-        if len(logs) == 0:
-            raise ValueError("node {} failed to receive the message".format(self.name))
-        log = logs.split('\n')[kth]
-        time_str = log.split(' ')[0]
-        match = re.search(r'\x1b\[[0-9;]+[A-Za-z]([:\.0-9]+)', time_str)
-        if match is not None:
-            time_str = match[1]
-        timestamp = datetime.strptime(time_str, '%H:%M:%S.%f')
-        return timestamp
-
-
-def make_node(seed, bootnodes=None):
-    n = Node(
-        get_docker_host_ip(),
-        seed + PORT_BASE,
-        seed + RPC_PORT_BASE,
-        seed,
-    )
-    n.run(bootnodes)
-    return n
-
-
-def make_local_nodes(low, top, bootnodes=None):
-    nodes = []
-    threads = []
-
-    def run_node(seed, bootnodes=None):
-        node = make_node(seed, bootnodes)
-        nodes.append(node)
-
-    for i in range(low, top):
-        t = threading.Thread(target=run_node, args=(i, bootnodes))
-        t.start()
-        threads.append(t)
-    for t in threads:
-        t.join()
-    sorted(nodes, key=lambda node: node.seed)
-
-    time.sleep(2)
-    threads = []
     for node in nodes:
-        t = threading.Thread(target=node.set_peer_id, args=())
-        t.start()
-        threads.append(t)
-    for t in threads:
-        t.join()
-    return nodes
+        node.subscribe_shard([0])
+    print("Broadcasting collations...", end='')
+    nodes[0].broadcast_collation(0, num_collations, collation_size, collation_time)  # 1MB
+    print("done")
+
+    print("Gathering time...", end='')
+    time_broadcast = nodes[0].wait_for_log('rpcserver:BroadcastCollation: finished', 0)
+    time_received = nodes[-1].wait_for_log(
+        'Validating the received message',
+        num_collations - 1,
+    )
+    print("done")
+    print(
+        "time to broadcast all data to the last node: \x1b[0;37m1{}".format(
+            time_received - time_broadcast,
+        )
+    )
+
+    print("Cleaning up the nodes", end='')
+    kill_nodes(nodes)
+    print("done")
 
 
-def connect_barbell(nodes):
-    threads = []
-    for i in range(len(nodes) - 1):
-        t = threading.Thread(target=nodes[i].add_peer, args=(nodes[i + 1],))
-        t.start()
-        threads.append(t)
-    for t in threads:
-        t.join()
-
-
-def connect_fully(nodes):
-    threads = []
-    for i in range(len(nodes) - 1):
-        for j in range(i + 1, len(nodes)):
-            t = threading.Thread(target=nodes[i].add_peer, args=(nodes[j],))
-            t.start()
-            threads.append(t)
-    for t in threads:
-        t.join()
-
-
-def ensure_barbell_connections(nodes):
-    threads = []
-
-    def check_connection(nodes, i):
-        if len(nodes) <= 1:
-            return
-        peers = nodes[i].list_peer()
-        if i == 0:
-            assert len(peers) == 1 and peers[0] == nodes[i + 1].peer_id
-        elif i == len(nodes) - 1:
-            assert len(peers) == 1 and peers[0] == nodes[i - 1].peer_id
-        else:
-            assert len(peers) == 2 and \
-                (nodes[i - 1].peer_id in peers) and (nodes[i + 1].peer_id in peers)
-
-    for idx, _ in enumerate(nodes):
-        t = threading.Thread(target=check_connection, args=(nodes, idx))
-        t.start()
-        threads.append(t)
-    for t in threads:
-        t.join()
-
-
-if __name__ == "__main__":
-    num_bootnodes = 5
-    num_normal_nodes = 0
+def test_boot_nodes():
+    num_bootnodes = 2
+    num_normal_nodes = 10
     print("Spinning up {} bootnodes...".format(num_bootnodes), end='')
     bootnodes = make_local_nodes(0, num_bootnodes)
     print("done")
@@ -284,22 +90,13 @@ if __name__ == "__main__":
     for node in bootnodes:
         node.subscribe_shard([0])
     print("Broadcasting collations...", end='')
-    num_collations = 10
+    num_collations = 20
     bootnodes[0].broadcast_collation(0, num_collations, 1000000, 50)  # 1MB
     print("done")
     print("Waiting for messages broadcasted...", end='')
     # TODO: maybe using something like `wait_until`, instead of a fixed sleeping time
     #       This way, we don't need to measure the sleeping time in advance
-    time.sleep(2)
     print("done")
-
-    time_broadcast = bootnodes[0].get_log_time('rpcserver:BroadcastCollation: finished', 0)
-    time_received = bootnodes[-1].get_log_time(
-        'Validating the received message',
-        num_collations - 1,
-    )
-    print("time to broadcast to the last node:", time_received - time_broadcast)
-
 
     bootnodes_multiaddr = [node.multiaddr for node in bootnodes]
     print("Spinning up {} nodes...".format(num_normal_nodes), end='')
@@ -310,12 +107,10 @@ if __name__ == "__main__":
     time.sleep(3)
     print("done")
 
-    # kill all nodes
     print("Cleaning up the nodes", end='')
-    bootnode_names = [n.name for n in bootnodes]
-    node_names = [n.name for n in nodes]
-    subprocess.run(
-        ["docker", "kill"] + bootnode_names + node_names,
-        stdout=subprocess.PIPE,
-    )
+    kill_nodes(bootnodes + nodes)
     print("done")
+
+
+if __name__ == "__main__":
+    test_time_broadcasting_data_single_shard()

--- a/test/test_one_shard.py
+++ b/test/test_one_shard.py
@@ -78,16 +78,19 @@ class Node:
         """`bootnodes` should be a list of string. Each string should be a multiaddr.
         """
         self.close()
-        cmd = "docker run -d --name {} -p {}:10000 -p {}:13000 ethereum/sharding-p2p:dev sh -c \"./sharding-p2p-poc -loglevel=DEBUG -ip=0.0.0.0 -seed={}\"".format(
+        bootnodes_cmd = ""
+        if bootnodes is not None:
+            bootnodes_cmd = "-bootstrap -bootnodes={}".format(
+            ",".join(bootnodes),
+        )
+        cmd = "docker run -d --name {} -p {}:10000 -p {}:13000 ethereum/sharding-p2p:dev sh -c \"./sharding-p2p-poc -loglevel=DEBUG -ip=0.0.0.0 -seed={} {}\"".format(
             self.name,
             self.port,
             self.rpc_port,
             self.seed,
+            bootnodes_cmd,
         )
-        if bootnodes is not None:
-            cmd += " -bootstrap -bootnodes={}".format(
-                ",".join(bootnodes),
-            )
+        print(cmd)
         subprocess.run(cmd, shell=True, check=True)
 
     def cli(self, cmd, **kwargs):

--- a/test/test_series.py
+++ b/test/test_series.py
@@ -13,9 +13,11 @@ import os
 import time
 
 from utils import (
-    connect_barbell,
-    ensure_barbell_connections,
+    connect_nodes,
+    ensure_topology,
+    get_actual_topology,
     kill_nodes,
+    make_barbell_topology,
     make_local_nodes,
 )
 
@@ -44,10 +46,11 @@ def test_time_broadcasting_data_single_shard():
     nodes = make_local_nodes(0, num_nodes)
     print("done")
     print("Connecting nodes...", end='')
-    connect_barbell(nodes)
+    topo = make_barbell_topology(nodes)
+    connect_nodes(nodes, topo)
     print("done")
     print("Checking the connections...", end='')
-    ensure_barbell_connections(nodes)
+    ensure_topology(nodes, topo)
     print("done")
 
     for node in nodes:
@@ -81,17 +84,18 @@ def test_time_broadcasting_data_single_shard():
     print("done")
 
 
-def test_boot_nodes():
+def test_joining_through_bootnodes():
     num_bootnodes = 1
     num_normal_nodes = 10
     print("Spinning up {} bootnodes...".format(num_bootnodes), end='')
     bootnodes = make_local_nodes(0, num_bootnodes)
     print("done")
     print("Connecting bootnodes...", end='')
-    connect_barbell(bootnodes)
+    topo = make_barbell_topology(bootnodes)
+    connect_nodes(bootnodes, topo)
     print("done")
     print("Checking the connections...", end='')
-    ensure_barbell_connections(bootnodes)
+    ensure_topology(bootnodes, topo)
     print("done")
 
     bootnodes_multiaddr = [node.multiaddr for node in bootnodes]
@@ -103,10 +107,15 @@ def test_boot_nodes():
     time.sleep(3)
     print("done")
 
+    all_nodes = bootnodes + nodes
+    actual_topo = get_actual_topology(all_nodes)
+    print("actual_topo =", actual_topo)
+
     print("Cleaning up the nodes...", end='')
-    kill_nodes(bootnodes + nodes)
+    kill_nodes(all_nodes)
     print("done")
 
 
 if __name__ == "__main__":
     test_time_broadcasting_data_single_shard()
+    test_joining_through_bootnodes()

--- a/test/utils.py
+++ b/test/utils.py
@@ -72,8 +72,8 @@ class Node:
         bootnodes_cmd = ""
         if bootnodes is not None:
             bootnodes_cmd = "-bootstrap -bootnodes={}".format(
-            ",".join(bootnodes),
-        )
+                ",".join(bootnodes),
+            )
         cmd = "docker run -d --name {} -p {}:10000 -p {}:13000 ethresearch/sharding-p2p:dev sh -c \"./sharding-p2p-poc -loglevel=DEBUG -ip=0.0.0.0 -seed={} {}\"".format(
             self.name,
             self.port,
@@ -106,7 +106,6 @@ class Node:
     def cli_safe(self, cmd):
         res = self.cli(cmd)
         if res.returncode != 0:
-            print(res)
             raise CLIFailure(
                 "exit_code={}, stdout={!r}, stderr={!r}".format(
                     res.returncode,
@@ -133,16 +132,16 @@ class Node:
         return self.cli_safe("listtopic {}".format(' '.join(topics)))
 
     def subscribe_shard(self, shard_ids):
-        return self.cli_safe("subshard {}".format(' '.join(map(str, shard_ids))))
+        self.cli_safe("subshard {}".format(' '.join(map(str, shard_ids))))
 
     def unsubscribe_shard(self, shard_ids):
-        return self.cli_safe("unsubshard {}".format(' '.join(map(str, shard_ids))))
+        self.cli_safe("unsubshard {}".format(' '.join(map(str, shard_ids))))
 
     def get_subscribed_shard(self):
         return self.cli_safe("getsubshard")
 
     def broadcast_collation(self, shard_id, num_collations, collation_size, collation_time):
-        return self.cli_safe("broadcastcollation {} {} {} {}".format(
+        self.cli_safe("broadcastcollation {} {} {} {}".format(
             shard_id,
             num_collations,
             collation_size,
@@ -150,7 +149,7 @@ class Node:
         ))
 
     def stop(self):
-        return self.cli_safe("stop")
+        self.cli_safe("stop")
 
     def grep_log(self, pattern):
         res = subprocess.run(
@@ -195,8 +194,6 @@ class Node:
     def get_log_time(self, pattern, k_th):
         log = self.wait_for_log(pattern, k_th)
         time_str_iso8601 = log.split(' ')[0]
-        # # get rid of the control elements
-        # match = re.search(r'\x1b\[[0-9;]+[A-Za-z]([:\.0-9]+)', time_str)
         return parser.parse(time_str_iso8601)
 
 
@@ -227,8 +224,7 @@ def make_local_nodes(low, top, bootnodes=None):
         t.join()
     nodes = sorted(nodes, key=lambda node: node.seed)
 
-    sleep_time = 5
-    time.sleep(sleep_time)
+    time.sleep(5)
 
     threads = []
     for node in nodes:
@@ -292,7 +288,6 @@ def make_peer_id_map(nodes):
 
 def get_actual_topology(nodes):
     map_peer_id_to_seed = make_peer_id_map(nodes)
-    print(map_peer_id_to_seed)
     topo = defaultdict(set)
     for node in nodes:
         peers = node.list_peer()

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,0 +1,287 @@
+from datetime import (
+    datetime,
+)
+import json
+import re
+import subprocess
+import sys
+import threading
+import os
+import time
+
+from dateutil import (
+    parser,
+)
+
+
+RPC_PORT_BASE = 13000
+PORT_BASE = 10000
+
+
+def get_docker_host_ip():
+    sysname = os.uname().sysname
+    if sysname != 'Darwin' and sysname != 'Linux':
+        raise ValueError(
+            "Failed to get ip in platforms other than Linux and macOS: {}".format(sysname)
+        )
+    cmd = 'ifconfig | grep -E "([0-9]{1,3}\\.){3}[0-9]{1,3}" | grep -v 127.0.0.1 | awk \'{ print $2 }\' | cut -f2 -d: | head -n1'
+    res = subprocess.run(cmd, shell=True, check=True, stdout=subprocess.PIPE, encoding='utf-8')
+    return res.stdout.rstrip()
+
+
+class CLIFailure(Exception):
+    pass
+
+
+class Node:
+
+    ip = None
+    port = None
+    rpc_port = None
+    peer_id = None
+    seed = None
+
+    def __init__(self, ip, port, rpc_port, seed):
+        self.ip = ip
+        self.port = port
+        self.rpc_port = rpc_port
+        self.seed = seed
+
+    def __repr__(self):
+        return "<Node seed={} peer_id={}>".format(
+            self.seed,
+            None if self.peer_id is None else self.peer_id[2:8],
+        )
+
+    @property
+    def name(self):
+        return f"whiteblock-node{self.seed}"
+
+    @property
+    def multiaddr(self):
+        return f"/ip4/{self.ip}/tcp/{self.port}/ipfs/{self.peer_id}"
+
+    def close(self):
+        subprocess.run(f"docker kill {self.name}", shell=True, stdout=subprocess.PIPE)
+        subprocess.run(f"docker rm -f {self.name}", shell=True, stdout=subprocess.PIPE)
+
+    def run(self, bootnodes=None):
+        """`bootnodes` should be a list of string. Each string should be a multiaddr.
+        """
+        self.close()
+        bootnodes_cmd = ""
+        if bootnodes is not None:
+            bootnodes_cmd = "-bootstrap -bootnodes={}".format(
+            ",".join(bootnodes),
+        )
+        cmd = "docker run -d --name {} -p {}:10000 -p {}:13000 ethresearch/sharding-p2p:dev sh -c \"./sharding-p2p-poc -loglevel=DEBUG -ip=0.0.0.0 -seed={} {}\"".format(
+            self.name,
+            self.port,
+            self.rpc_port,
+            self.seed,
+            bootnodes_cmd,
+        )
+        subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, check=True)
+
+    def cli(self, cmd, **kwargs):
+        cmd_list = cmd.split(' ')
+        cmd_quoted_param_list = ["'{}'".format(i) for i in cmd_list]
+        cmd_quoted_param_str = " ".join(cmd_quoted_param_list)
+        return subprocess.run(
+            [
+                "docker",
+                "exec",
+                "-t",
+                self.name,
+                "sh",
+                "-c",
+                "./sharding-p2p-poc '-client' {}".format(cmd_quoted_param_str),
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            encoding='utf-8',
+            **kwargs,
+        )
+
+    def cli_safe(self, cmd):
+        res = self.cli(cmd)
+        if res.returncode != 0:
+            print(res)
+            raise CLIFailure(
+                "exit_code={}, stdout={!r}, stderr={!r}".format(
+                    res.returncode,
+                    res.stdout,
+                    res.stderr,
+                )
+            )
+        out = res.stdout.rstrip()
+        # assume CLIs only reply data in JSON
+        if out != '':
+            return json.loads(out)
+        return out
+
+    def add_peer(self, node):
+        self.cli_safe("addpeer {} {} {}".format(node.ip, node.port, node.seed))
+
+    def remove_peer(self, peer_id):
+        self.cli_safe("removepeer {}".format(peer_id))
+
+    def list_peer(self):
+        return self.cli_safe("listpeer")
+
+    def list_topic_peer(self, topics):
+        return self.cli_safe("listtopic {}".format(' '.join(topics)))
+
+    def subscribe_shard(self, shard_ids):
+        return self.cli_safe("subshard {}".format(' '.join(map(str, shard_ids))))
+
+    def unsubscribe_shard(self, shard_ids):
+        return self.cli_safe("unsubshard {}".format(' '.join(map(str, shard_ids))))
+
+    def get_subscribed_shard(self):
+        return self.cli_safe("getsubshard")
+
+    def broadcast_collation(self, shard_id, num_collations, collation_size, collation_time):
+        return self.cli_safe("broadcastcollation {} {} {} {}".format(
+            shard_id,
+            num_collations,
+            collation_size,
+            collation_time,
+        ))
+
+    def stop(self):
+        return self.cli_safe("stop")
+
+    def grep_log(self, pattern):
+        res = subprocess.run(
+            [
+                "docker logs {} 2>&1 | grep '{}'".format(
+                    self.name,
+                    pattern,
+                ),
+            ],
+            shell=True,
+            stdout=subprocess.PIPE,
+            encoding='utf-8',
+        )
+        return res.stdout.rstrip()
+
+    def set_peer_id(self):
+        grep_res = self.grep_log('Node is listening')
+        match = re.search(r'peerID=([a-zA-Z0-9]+) ', grep_res)
+        if match is None:
+            raise ValueError("failed to grep the peer_id from docker logs")
+        self.peer_id = match[1]
+
+    def wait_for_log(self, pattern, k_th):
+        """Wait for the `k_th` log in the format of `pattern`
+        """
+        # TODO: should set a `timeout`?
+        cmd = "docker logs {} -t -f 2>&1 | grep --line-buffered '{}' -m {}".format(
+            self.name,
+            pattern,
+            k_th + 1,
+        )
+        res = subprocess.run(
+            [cmd],
+            shell=True,
+            stdout=subprocess.PIPE,
+            encoding='utf-8',
+        )
+        logs = res.stdout.rstrip()
+        log = logs.split('\n')[k_th]
+        time_str_iso8601 = log.split(' ')[0]
+        # # get rid of the control elements
+        # match = re.search(r'\x1b\[[0-9;]+[A-Za-z]([:\.0-9]+)', time_str)
+        return parser.parse(time_str_iso8601)
+
+def make_node(seed, bootnodes=None):
+    n = Node(
+        get_docker_host_ip(),
+        seed + PORT_BASE,
+        seed + RPC_PORT_BASE,
+        seed,
+    )
+    n.run(bootnodes)
+    return n
+
+
+def make_local_nodes(low, top, bootnodes=None):
+    nodes = []
+    threads = []
+
+    def run_node(seed, bootnodes=None):
+        node = make_node(seed, bootnodes)
+        nodes.append(node)
+
+    for i in range(low, top):
+        t = threading.Thread(target=run_node, args=(i, bootnodes))
+        t.start()
+        threads.append(t)
+    for t in threads:
+        t.join()
+    nodes = sorted(nodes, key=lambda node: node.seed)
+
+    sleep_time = 5 + (top - low)
+    time.sleep(sleep_time)
+
+    threads = []
+    for node in nodes:
+        t = threading.Thread(target=node.set_peer_id, args=())
+        t.start()
+        threads.append(t)
+    for t in threads:
+        t.join()
+    return nodes
+
+
+def connect_barbell(nodes):
+    threads = []
+    for i in range(len(nodes) - 1):
+        t = threading.Thread(target=nodes[i].add_peer, args=(nodes[i + 1],))
+        t.start()
+        threads.append(t)
+    for t in threads:
+        t.join()
+
+
+def connect_fully(nodes):
+    threads = []
+    for i in range(len(nodes) - 1):
+        for j in range(i + 1, len(nodes)):
+            t = threading.Thread(target=nodes[i].add_peer, args=(nodes[j],))
+            t.start()
+            threads.append(t)
+    for t in threads:
+        t.join()
+
+
+def ensure_barbell_connections(nodes):
+    threads = []
+
+    def check_connection(nodes, i):
+        if len(nodes) <= 1:
+            return
+        peers = nodes[i].list_peer()
+        if i == 0:
+            assert len(peers) == 1 and peers[0] == nodes[i + 1].peer_id
+        elif i == len(nodes) - 1:
+            assert len(peers) == 1 and peers[0] == nodes[i - 1].peer_id
+        else:
+            assert len(peers) == 2 and \
+                (nodes[i - 1].peer_id in peers) and (nodes[i + 1].peer_id in peers)
+
+    for idx, _ in enumerate(nodes):
+        t = threading.Thread(target=check_connection, args=(nodes, idx))
+        t.start()
+        threads.append(t)
+    for t in threads:
+        t.join()
+
+
+def kill_nodes(nodes):
+    node_names = [n.name for n in nodes]
+    subprocess.run(
+        ["docker", "kill"] + node_names,
+        stdout=subprocess.PIPE,
+    )


### PR DESCRIPTION
This PR includes the testing script `test/test_series.py`, which is capable of
- spinning up `n` docker nodes with `sharding-p2p-poc` running, connecting nodes, and broadcasting data
- measuring how much time it takes to receive a broadcasted data
- testing if the bootnodes functioning well

Also, added logs and fixes https://github.com/ethresearch/sharding-p2p-poc/issues/105 in `ShardManager`

#### TODO
- [x] Organize the CLI outputs
- [x] Finish the first testing logic(one shard, how long it takes to broadcast to X% nodes)

#### How to run it
```python
cd test
pip install python-dateutil
python test_series.py
```

#### Note
- The script becomes slower when the number of nodes becomes larger, i.e. 100. Should find out the reason and solve it.
- The script uses threads when spinning up nodes and performing some CLIs, to reduce the time consumed. Probably need to change it when it consumes too many resources when the number of nodes becomes larger.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://scontent.ftpe7-4.fna.fbcdn.net/v/t1.0-9/45426782_1100184756842591_7035655596242108416_o.jpg?_nc_cat=101&_nc_ht=scontent.ftpe7-4.fna&oh=1b12a157d42914493cf666bec15102c8&oe=5C6D063B)
