### PR TITLE
resolves #102: modified the name of the image in the build-dev rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build-prod:
 	docker build -f docker/prod.Dockerfile -t ethereum/sharding-p2p:latest .
 
 build-dev:
-	docker build -f docker/dev.Dockerfile -t ethresearch/sharding-p2p:dev .
+	docker build -f docker/dev.Dockerfile -t ethereum/sharding-p2p:dev .
 
 run-dev:
 	docker run -it --rm -v $(PWD):/go/src/github.com/ethresearch/sharding-p2p-poc ethereum/sharding-p2p:dev sh -c "go build -v -o main ."

--- a/Makefile
+++ b/Makefile
@@ -8,16 +8,16 @@ deps: gx
 	python3 ./script/partial-gx-uw.py .
 
 build-prod:
-	docker build -f docker/prod.Dockerfile -t ethereum/sharding-p2p:latest .
+	docker build -f docker/prod.Dockerfile -t ethresearch/sharding-p2p:latest .
 
 build-dev:
-	docker build -f docker/dev.Dockerfile -t ethereum/sharding-p2p:dev .
+	docker build -f docker/dev.Dockerfile -t ethresearch/sharding-p2p:dev .
 
 run-dev:
-	docker run -it --rm -v $(PWD):/go/src/github.com/ethresearch/sharding-p2p-poc ethereum/sharding-p2p:dev sh -c "go build -v -o main ."
+	docker run -it --rm -v $(PWD):/go/src/github.com/ethresearch/sharding-p2p-poc ethresearch/sharding-p2p:dev sh -c "go build -v -o main ."
 
 test-dev: partial-gx-rw
-	docker run -it --rm -v $(PWD):/go/src/github.com/ethresearch/sharding-p2p-poc ethereum/sharding-p2p:dev sh -c "go test"
+	docker run -it --rm -v $(PWD):/go/src/github.com/ethresearch/sharding-p2p-poc ethresearch/sharding-p2p:dev sh -c "go test"
 	gx-go uw
 
 run-many-dev:


### PR DESCRIPTION
### What is wrong?

I get an 'unable to find image' error when busting a make run-dev:

```
$ make run-dev
docker run -it --rm -v /Users/jonny/go/src/github.com/ethresearch/sharding-p2p-poc:/go/src/github.com/ethresearch/sharding-p2p-poc ethereum/sharding-p2p:dev sh -c "go build -v -o main ."
Unable to find image 'ethereum/sharding-p2p:dev' locally
docker: Error response from daemon: pull access denied for ethereum/sharding-p2p, repository does not exist or may require 'docker login'.
See 'docker run --help'.
make: *** [run-dev] Error 125
```

### How can it be fixed?

Fix the docker build command in the Makefile:

```
$ git diff Makefile 
diff --git a/Makefile b/Makefile
index 0e63774..21da292 100644
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build-prod:
        docker build -f docker/prod.Dockerfile -t ethereum/sharding-p2p:latest .
 
 build-dev:
-       docker build -f docker/dev.Dockerfile -t ethresearch/sharding-p2p:dev .
+       docker build -f docker/dev.Dockerfile -t ethereum/sharding-p2p:dev .
 
 run-dev:
        docker run -it --rm -v $(PWD):/go/src/github.com/ethresearch/sharding-p2p-poc ethereum/sharding-p2p:dev sh -c "go build -v -o main ."
```


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://pbs.twimg.com/media/B1OprIvCcAA_EB6.jpg)
