### PR TITLE
Issue #10: added methods needed to implement listshardpeer

### DIFF
--- a/main.go
+++ b/main.go
@@ -106,6 +106,8 @@ func runClient(rpcAddr string, cliArgs []string) {
 		callRPCListPeer(rpcAddr)
 	case "listtopicpeer":
 		doListTopicPeer(rpcArgs, rpcAddr)
+	case "listshardpeer":
+		doListShardPeer(rpcArgs, rpcAddr)
 	case "removepeer":
 		doRemovePeer(rpcArgs, rpcAddr)
 	default:


### PR DESCRIPTION
Added a listshardpeer method for ease of use:

```
$ ./sharding-p2p-poc -port=10000 -rpcport=13000 -client listshardpeer 2 3 
{"2":[PEER_1,PEER_2],"3":[PEER_2,PEER_3]}
```
![put a cute animal picture link inside the parentheses](https://pbs.twimg.com/profile_images/3153449881/c043f1fa73612b1202240717f196e530_400x400.jpeg)
