### PR TITLE
Update gx version

### DIFF
--- a/discovery.go
+++ b/discovery.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"strconv"
 
-	pubsub "github.com/libp2p/go-floodsub"
 	host "github.com/libp2p/go-libp2p-host"
 	pstore "github.com/libp2p/go-libp2p-peerstore"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
 )
 
 type Discovery interface {

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,7 +41,7 @@ A global topic is used for every node to broadcast its "Shard Preference". A "Sh
 
 ### P2P Stack
 Currently, we use [go-libp2p](https://github.com/libp2p/go-libp2p) as the p2p stack.
-- [PubSub](https://github.com/libp2p/specs/tree/master/pubsub/gossipsub): we use [gossipsub](https://github.com/libp2p/go-floodsub/blob/master/gossipsub.go) right now. 
+- [PubSub](https://github.com/libp2p/specs/tree/master/pubsub/gossipsub): we use [gossipsub](https://github.com/libp2p/go-libp2p-pubsub/blob/master/gossipsub.go) right now. 
 - DHT: [go-libp2p-kad-dht](https://github.com/libp2p/go-libp2p-kad-dht)
 
 ### Functionalities

--- a/main.go
+++ b/main.go
@@ -235,6 +235,7 @@ func makeNode(
 		ctx,
 		libp2p.Identity(priv),
 		libp2p.ListenAddrStrings(listenAddrString),
+		libp2p.DisableRelay(),
 	)
 	if err != nil {
 		return nil, err

--- a/node.go
+++ b/node.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	pubsub "github.com/libp2p/go-floodsub"
 	host "github.com/libp2p/go-libp2p-host"
 	peer "github.com/libp2p/go-libp2p-peer"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	ma "github.com/multiformats/go-multiaddr"
 )
 

--- a/package.json
+++ b/package.json
@@ -9,20 +9,20 @@
   "gxDependencies": [
     {
       "author": "whyrusleeping",
-      "hash": "QmabWrc5aEQ36iWgJZonKgHpttvyDhHoWBoCtesuyMn9XF",
+      "hash": "QmVvV8JQmmqPCwXAaesWJPheUiEFQJ9HWRhWhuFuxVQxpR",
       "name": "go-libp2p",
-      "version": "6.0.20"
+      "version": "6.0.27"
     },
     {
-      "hash": "QmRMohiAZU9231TVUydLJfyiiEmXRJYpGVLDarhsLy4FU3",
+      "hash": "QmQsw6Nq2A345PqChdtbWVoYbSno7uqRDHwYmYpbPHmZNc",
       "name": "go-libp2p-kad-dht",
-      "version": "4.4.9"
+      "version": "4.4.16"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmUM8nuPYryeLY2ENKz8oX566H6HE2EPNQ3SQxjnEw3bD4",
+      "hash": "Qmc3BYVGtLs8y3p4uVpARWyo3Xk2oCBFF1AhYUVMPWgwUK",
       "name": "go-libp2p-floodsub",
-      "version": "0.10.1"
+      "version": "0.11.7"
     }
   ],
   "gxVersion": "0.12.1",

--- a/package.json
+++ b/package.json
@@ -9,20 +9,20 @@
   "gxDependencies": [
     {
       "author": "whyrusleeping",
-      "hash": "QmNmj2AeM46ZQqHARnWidb5qqHoZJFeYWzmG65jviJDRQY",
+      "hash": "QmabWrc5aEQ36iWgJZonKgHpttvyDhHoWBoCtesuyMn9XF",
       "name": "go-libp2p",
-      "version": "6.0.15"
+      "version": "6.0.20"
     },
     {
-      "hash": "QmXKSnQHAihkcGgk8ZXz7FgZgHboXeRduuEz9FkAddJK6P",
+      "hash": "QmRMohiAZU9231TVUydLJfyiiEmXRJYpGVLDarhsLy4FU3",
       "name": "go-libp2p-kad-dht",
-      "version": "4.4.4"
+      "version": "4.4.9"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmUK4h113Hh7bR2gPpsMcbUEbbzc7hspocmPi91Bmi69nH",
+      "hash": "QmUM8nuPYryeLY2ENKz8oX566H6HE2EPNQ3SQxjnEw3bD4",
       "name": "go-libp2p-floodsub",
-      "version": "0.9.31"
+      "version": "0.10.1"
     }
   ],
   "gxVersion": "0.12.1",

--- a/shardmanager.go
+++ b/shardmanager.go
@@ -6,9 +6,9 @@ import (
 	"strconv"
 	"sync"
 
-	pubsub "github.com/libp2p/go-floodsub"
 	host "github.com/libp2p/go-libp2p-host"
 	pstore "github.com/libp2p/go-libp2p-peerstore"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
 
 	pbmsg "github.com/ethresearch/sharding-p2p-poc/pb/message"
 	"github.com/golang/protobuf/proto"


### PR DESCRIPTION
### What was wrong?
During solving #100 , an update of `go-libp2p-crypto` is needed.


### How was it fixed?
Update `go-libp2p` along with `go-libp2p-kad-dht` and `go-libp2p-pubsub`.

**NOTE**: After updated `go-libp2p`, connecting peer keeps failing with error: `dial attempt failed: Failed to dial through 0 known relay hosts`.
And currently this is solved by disabling Relay when instantiating a libp2p host: `libp2p.New(…, libp2p.DisableRelay(), …)`. Should further investigate on how to use Relay.

#### Cute Animal Picture

![](https://cdn.pixabay.com/photo/2015/11/16/20/39/cat-1046343_1280.jpg)
