### PR TITLE
Add RPC `bootstrap`

### DIFF
--- a/cli-example/common.sh
+++ b/cli-example/common.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+
+
+EXE_NAME="./sharding-p2p-poc"
+IP=127.0.0.1
+PORT=10000
+RPCPORT=13000
+LOGLEVEL="DEBUG"
+
+# show_port {seed}
+show_port() {
+    echo $((PORT+$1))
+}
+
+# show_rpcport {seed}
+show_rpcport() {
+    echo $((RPCPORT+$1))
+}
+
+# spinup_node {seed} {other_params}
+spinup_node() {
+    seed=$1
+    port=$(show_port $seed)
+    rpcport=$(show_rpcport $seed)
+    p=$@
+    params=${@:2}
+    $EXE_NAME -seed=$seed -port=$port -rpcport=$rpcport -loglevel=$LOGLEVEL $params &
+}
+
+cli_prompt() {
+    p=$@
+    seed=$1
+    params=${@:2}
+    echo "$EXE_NAME -rpcport=$((RPCPORT+seed)) -client $params"
+}
+
+# show_pid {seed}
+show_pid() {
+    seed=$1
+    pid_str=$(`cli_prompt $seed` pid)
+    pid=${pid_str:1:${#pid_str}-2}
+    echo $pid
+}
+
+# show_multiaddr {seed}
+show_multiaddr() {
+    seed=$1
+    port=$(show_port $seed)
+    pid=$(show_pid $seed)
+    echo "/ip4/127.0.0.1/tcp/$port/ipfs/$pid"
+}
+
+# add_peer {seed0} {seed1}
+add_peer() {
+    seed0=$1
+    seed1=$2
+    `cli_prompt $seed0` addpeer $IP $((PORT+seed1)) $seed1
+}
+
+# subscribe_shard {seed} {shard_id} {shard_id} ...
+subscribe_shard() {
+    p=$@
+    seed=$1
+    params=${@:2}
+    `cli_prompt $seed` subshard $params
+}
+
+# unsubscribe_shard {seed} {shard_id} {shard_id} ...
+unsubscribe_shard() {
+    p=$@
+    seed=$1
+    params=${@:2}
+    `cli_prompt $seed` unsubshard $params
+}
+
+# get_subscribe_shard {seed}
+get_subscribe_shard() {
+    p=$@
+    seed=$1
+    `cli_prompt $seed` getsubshard
+}
+
+# broadcast_collation {seed} {shard_id} {num_collation} {size} {period}
+broadcast_collation() {
+    p=$@
+    seed=$1
+    params=${@:2}
+    `cli_prompt $seed` broadcastcollation $params
+}
+
+# stop_server {seed}
+stop_server() {
+    p=$@
+    seed=$1
+    `cli_prompt $seed` stop
+}
+
+# listpeer {seed}
+list_peer() {
+    p=$@
+    seed=$1
+    `cli_prompt $seed` listpeer
+}
+
+
+# listtopicpeer {seed} {topic0} {topic1} ...
+list_topic_peer() {
+    p=$@
+    seed=$1
+    `cli_prompt $seed` listtopicpeer
+}
+
+# remove_peer {seed} peerID
+remove_peer() {
+    p=$@
+    seed=$1
+    params=${@:2}
+    `cli_prompt $seed` removepeer $params
+}
+
+# bootstrap {seed} {start/stop} {bootnodesStr}
+bootstrap() {
+    p=$@
+    seed=$1
+    params=${@:2}
+    `cli_prompt $seed` bootstrap $params
+}

--- a/cli-example/common.sh
+++ b/cli-example/common.sh
@@ -31,7 +31,7 @@ cli_prompt() {
     p=$@
     seed=$1
     params=${@:2}
-    echo "$EXE_NAME -rpcport=$((RPCPORT+seed)) -client $params"
+    echo "$EXE_NAME -rpcport=$(show_rpcport $seed) -client $params"
 }
 
 # show_pid {seed}
@@ -54,7 +54,7 @@ show_multiaddr() {
 add_peer() {
     seed0=$1
     seed1=$2
-    `cli_prompt $seed0` addpeer $IP $((PORT+seed1)) $seed1
+    `cli_prompt $seed0` addpeer $IP $(show_port $seed1) $seed1
 }
 
 # subscribe_shard {seed} {shard_id} {shard_id} ...

--- a/cli-example/iterate_all_rpc_call.sh
+++ b/cli-example/iterate_all_rpc_call.sh
@@ -97,6 +97,13 @@ remove_peer() {
     `cli_prompt $seed` removepeer $params
 }
 
+# bootstrap {seed} {start/stop} {bootnodesStr}
+bootstrap() {
+    p=$@
+    seed=$1
+    params=${@:2}
+    `cli_prompt $seed` bootstrap $params
+}
 
 
 go build
@@ -149,6 +156,9 @@ list_peer 0
 list_topic_peer 0
 
 remove_peer 0 QmexAnfpHrhMmAC5UNQVS8iBuUUgDrMbMY17Cck2gKrqeX
+
+bootstrap 0 start /ip4/127.0.0.1/tcp/10001/ipfs/QmexAnfpHrhMmAC5UNQVS8iBuUUgDrMbMY17Cck2gKrqeX
+bootstrap 0 stop
 
 for i in `seq 0 1`;
 do

--- a/cli-example/iterate_all_rpc_call.sh
+++ b/cli-example/iterate_all_rpc_call.sh
@@ -1,110 +1,8 @@
 #!/bin/bash
 # This script is expected to be executed in the root dir of the repo
 
-EXE_NAME="./sharding-p2p-poc"
-IP=127.0.0.1
-PORT=10000
-RPCPORT=13000
-LOGLEVEL="DEBUG"
-
-# spinup_node {seed} {other_params}
-spinup_node() {
-    port=$((PORT+$1))
-    rpcport=$((RPCPORT+$1))
-    p=$@
-    params=${@:2}
-    $EXE_NAME -seed=$1 -port=$port -rpcport=$rpcport -loglevel=$LOGLEVEL $params &
-}
-
-cli_prompt() {
-    p=$@
-    seed=$1
-    params=${@:2}
-    echo "$EXE_NAME -rpcport=$((RPCPORT+seed)) -client $params"
-}
-
-# show_pid {seed}
-show_pid() {
-    seed=$1
-    `cli_prompt $seed` pid
-}
-
-# add_peer {seed0} {seed1}
-add_peer() {
-    seed0=$1
-    seed1=$2
-    `cli_prompt $seed0` addpeer $IP $((PORT+seed1)) $seed1
-}
-
-# subscribe_shard {seed} {shard_id} {shard_id} ...
-subscribe_shard() {
-    p=$@
-    seed=$1
-    params=${@:2}
-    `cli_prompt $seed` subshard $params
-}
-
-# unsubscribe_shard {seed} {shard_id} {shard_id} ...
-unsubscribe_shard() {
-    p=$@
-    seed=$1
-    params=${@:2}
-    `cli_prompt $seed` unsubshard $params
-}
-
-# get_subscribe_shard {seed}
-get_subscribe_shard() {
-    p=$@
-    seed=$1
-    `cli_prompt $seed` getsubshard
-}
-
-# broadcast_collation {seed} {shard_id} {num_collation} {size} {period}
-broadcast_collation() {
-    p=$@
-    seed=$1
-    params=${@:2}
-    `cli_prompt $seed` broadcastcollation $params
-}
-
-# stop_server {seed}
-stop_server() {
-    p=$@
-    seed=$1
-    `cli_prompt $seed` stop
-}
-
-# listpeer {seed}
-list_peer() {
-    p=$@
-    seed=$1
-    `cli_prompt $seed` listpeer
-}
-
-
-# listtopicpeer {seed} {topic0} {topic1} ...
-list_topic_peer() {
-    p=$@
-    seed=$1
-    `cli_prompt $seed` listtopicpeer
-}
-
-# remove_peer {seed} peerID
-remove_peer() {
-    p=$@
-    seed=$1
-    params=${@:2}
-    `cli_prompt $seed` removepeer $params
-}
-
-# bootstrap {seed} {start/stop} {bootnodesStr}
-bootstrap() {
-    p=$@
-    seed=$1
-    params=${@:2}
-    `cli_prompt $seed` bootstrap $params
-}
-
+COMMAND_SCRIPT="$(dirname $0)/common.sh"
+. $COMMAND_SCRIPT
 
 go build
 
@@ -155,9 +53,9 @@ list_peer 0
 
 list_topic_peer 0
 
-remove_peer 0 QmexAnfpHrhMmAC5UNQVS8iBuUUgDrMbMY17Cck2gKrqeX
+remove_peer 0 $(show_pid 1)
 
-bootstrap 0 start /ip4/127.0.0.1/tcp/10001/ipfs/QmexAnfpHrhMmAC5UNQVS8iBuUUgDrMbMY17Cck2gKrqeX
+bootstrap 0 start $(show_multiaddr 1)
 bootstrap 0 stop
 
 for i in `seq 0 1`;

--- a/cli-example/setup-4-nodes.sh
+++ b/cli-example/setup-4-nodes.sh
@@ -1,33 +1,8 @@
 #!/bin/bash
 # This script is expected to be executed in the root dir of the repo
 
-EXE_NAME="./sharding-p2p-poc"
-IP=127.0.0.1
-PORT=10000
-RPCPORT=13000
-
-# spinup_node {seed} {other_params}
-spinup_node() {
-    port=$((PORT+$1))
-    rpcport=$((RPCPORT+$1))
-    p=$@
-    params=${@:2}
-    $EXE_NAME -seed=$1 -port=$port -rpcport=$rpcport $params &
-}
-
-cli_prompt() {
-    p=$@
-    seed=$1
-    params=${@:2}
-    echo "$EXE_NAME -rpcport=$((RPCPORT+seed)) -client $params"
-}
-
-# add_peer {seed0} {seed1}
-add_peer() {
-    seed0=$1
-    seed1=$2
-    `cli_prompt $seed0` addpeer $IP $((PORT+seed1)) $seed1
-}
+COMMAND_SCRIPT="$(dirname $0)/common.sh"
+. $COMMAND_SCRIPT
 
 # make partial-gx-rw
 go build
@@ -44,10 +19,7 @@ sleep 2
 add_peer 0 1
 add_peer 1 2
 
-multiaddr0=/ip4/127.0.0.1/tcp/10000/ipfs/QmS5QmciTXXnCUCyxud5eWFenUMAmvAWSDa1c7dvdXRMZ7
-multiaddr1=/ip4/127.0.0.1/tcp/10001/ipfs/QmexAnfpHrhMmAC5UNQVS8iBuUUgDrMbMY17Cck2gKrqeX
-
-spinup_node 3 -bootstrap -bootnodes=$multiaddr0,$multiaddr1
+spinup_node 3 -bootstrap -bootnodes=$(show_multiaddr 0),$(show_multiaddr 1)
 
 # make gx-uw
 

--- a/cli-example/setup-4-nodes.sh
+++ b/cli-example/setup-4-nodes.sh
@@ -4,7 +4,6 @@
 COMMAND_SCRIPT="$(dirname $0)/common.sh"
 . $COMMAND_SCRIPT
 
-# make partial-gx-rw
 go build
 
 killall $EXE_NAME
@@ -20,6 +19,3 @@ add_peer 0 1
 add_peer 1 2
 
 spinup_node 3 -bootstrap -bootnodes=$(show_multiaddr 0),$(show_multiaddr 1)
-
-# make gx-uw
-

--- a/main.go
+++ b/main.go
@@ -234,7 +234,6 @@ func makeNode(
 	eventNotifier EventNotifier,
 	doBootstrapping bool,
 	bootstrapPeers []pstore.PeerInfo) (*Node, error) {
-	// FIXME: should be set to localhost if we don't want to expose it to outside
 	listenAddrString := fmt.Sprintf("/ip4/%v/tcp/%v", listenIP, listenPort)
 
 	priv, _, err := makeKey(randseed)
@@ -261,18 +260,11 @@ func makeNode(
 	// Make the routed host
 	routedHost := rhost.Wrap(basicHost, dht)
 
-	if doBootstrapping {
-		// try to connect to the chosen nodes
-		bootstrapConnect(ctx, routedHost, bootstrapPeers)
-
-		err = dht.Bootstrap(ctx)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	// Make a host that listens on the given multiaddress
-	node := NewNode(ctx, routedHost, eventNotifier)
+	node := NewNode(ctx, routedHost, dht, eventNotifier)
+	if doBootstrapping {
+		node.StartBootstrapping(ctx, bootstrapPeers)
+	}
 
 	return node, nil
 }

--- a/main.go
+++ b/main.go
@@ -123,6 +123,8 @@ func runClient(rpcAddr string, cliArgs []string) {
 		doListShardPeer(rpcArgs, rpcAddr)
 	case "removepeer":
 		doRemovePeer(rpcArgs, rpcAddr)
+	case "bootstrap":
+		doBootstrap(rpcArgs, rpcAddr)
 	default:
 		logger.Fatalf("Client: Invalid cmd '%v'", rpcCmd)
 	}

--- a/node.go
+++ b/node.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 
 	host "github.com/libp2p/go-libp2p-host"
+	kaddht "github.com/libp2p/go-libp2p-kad-dht"
 	peer "github.com/libp2p/go-libp2p-peer"
+	pstore "github.com/libp2p/go-libp2p-peerstore"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	ma "github.com/multiformats/go-multiaddr"
 )
@@ -17,19 +19,25 @@ type Node struct {
 	*ShardManager
 
 	ctx context.Context
+
+	dht                 *kaddht.IpfsDHT
+	doBootstrapping     bool
+	cancelBootstrapping context.CancelFunc
 }
 
 // NewNode creates a new node with its implemented protocols
-func NewNode(ctx context.Context, h host.Host, eventNotifier EventNotifier) *Node {
+func NewNode(ctx context.Context, h host.Host, dht *kaddht.IpfsDHT, eventNotifier EventNotifier) *Node {
 	shardPrefTable := NewShardPrefTable()
 	pubsubService, err := pubsub.NewGossipSub(ctx, h)
 	if err != nil {
 		logger.Fatalf("Failed to create new pubsub service, err: %v", err)
 	}
 	node := &Node{
-		Host:      h,
-		ctx:       ctx,
-		discovery: NewGlobalTable(ctx, h, pubsubService, shardPrefTable),
+		Host:            h,
+		discovery:       NewGlobalTable(ctx, h, pubsubService, shardPrefTable),
+		ctx:             ctx,
+		dht:             dht,
+		doBootstrapping: false,
 	}
 	node.RequestProtocol = NewRequestProtocol(node)
 	node.ShardManager = NewShardManager(ctx, node, pubsubService, eventNotifier, node.discovery, shardPrefTable)
@@ -55,4 +63,40 @@ func (n *Node) IsPeer(peerID peer.ID) bool {
 		}
 	}
 	return false
+}
+
+//StartBootstrapping starts the bootstrapping process in dht, with the contact peers
+// `bootstrapPeers`.
+func (n *Node) StartBootstrapping(ctx context.Context, bootstrapPeers []pstore.PeerInfo) error {
+	if n.doBootstrapping {
+		return nil
+	}
+	// try to connect to the chosen nodes
+	bootstrapConnect(ctx, n, bootstrapPeers)
+
+	bootstrapCtx, cancel := context.WithCancel(ctx)
+	err := n.dht.Bootstrap(bootstrapCtx)
+	if err != nil {
+		return err
+	}
+	n.doBootstrapping = true
+	n.cancelBootstrapping = cancel
+	return nil
+}
+
+//IsBootstrapping indicates if the node is bootstrapping
+func (n *Node) IsBootstrapping() bool {
+	return n.doBootstrapping
+}
+
+//StopBootstrapping stops the bootstrapping process, using the cancel function results from
+// `StartBootstrapping`
+func (n *Node) StopBootstrapping() error {
+	if !n.doBootstrapping {
+		return nil
+	}
+	n.cancelBootstrapping()
+	n.doBootstrapping = false
+	n.cancelBootstrapping = nil
+	return nil
 }

--- a/pb/rpc/rpc.pb.go
+++ b/pb/rpc/rpc.pb.go
@@ -3,13 +3,14 @@
 
 package proto_rpc
 
+import proto "github.com/golang/protobuf/proto"
+import fmt "fmt"
+import math "math"
+import message "github.com/ethresearch/sharding-p2p-poc/pb/message"
+
 import (
-	context "context"
-	fmt "fmt"
-	message "github.com/ethresearch/sharding-p2p-poc/pb/message"
-	proto "github.com/golang/protobuf/proto"
+	context "golang.org/x/net/context"
 	grpc "google.golang.org/grpc"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -34,17 +35,16 @@ func (m *RPCShowPIDRequest) Reset()         { *m = RPCShowPIDRequest{} }
 func (m *RPCShowPIDRequest) String() string { return proto.CompactTextString(m) }
 func (*RPCShowPIDRequest) ProtoMessage()    {}
 func (*RPCShowPIDRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_77a6da22d6a3feb1, []int{0}
+	return fileDescriptor_rpc_65400171214530d0, []int{0}
 }
-
 func (m *RPCShowPIDRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RPCShowPIDRequest.Unmarshal(m, b)
 }
 func (m *RPCShowPIDRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_RPCShowPIDRequest.Marshal(b, m, deterministic)
 }
-func (m *RPCShowPIDRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_RPCShowPIDRequest.Merge(m, src)
+func (dst *RPCShowPIDRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RPCShowPIDRequest.Merge(dst, src)
 }
 func (m *RPCShowPIDRequest) XXX_Size() int {
 	return xxx_messageInfo_RPCShowPIDRequest.Size(m)
@@ -66,17 +66,16 @@ func (m *RPCShowPIDResponse) Reset()         { *m = RPCShowPIDResponse{} }
 func (m *RPCShowPIDResponse) String() string { return proto.CompactTextString(m) }
 func (*RPCShowPIDResponse) ProtoMessage()    {}
 func (*RPCShowPIDResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_77a6da22d6a3feb1, []int{1}
+	return fileDescriptor_rpc_65400171214530d0, []int{1}
 }
-
 func (m *RPCShowPIDResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RPCShowPIDResponse.Unmarshal(m, b)
 }
 func (m *RPCShowPIDResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_RPCShowPIDResponse.Marshal(b, m, deterministic)
 }
-func (m *RPCShowPIDResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_RPCShowPIDResponse.Merge(m, src)
+func (dst *RPCShowPIDResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RPCShowPIDResponse.Merge(dst, src)
 }
 func (m *RPCShowPIDResponse) XXX_Size() int {
 	return xxx_messageInfo_RPCShowPIDResponse.Size(m)
@@ -107,17 +106,16 @@ func (m *RPCAddPeerRequest) Reset()         { *m = RPCAddPeerRequest{} }
 func (m *RPCAddPeerRequest) String() string { return proto.CompactTextString(m) }
 func (*RPCAddPeerRequest) ProtoMessage()    {}
 func (*RPCAddPeerRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_77a6da22d6a3feb1, []int{2}
+	return fileDescriptor_rpc_65400171214530d0, []int{2}
 }
-
 func (m *RPCAddPeerRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RPCAddPeerRequest.Unmarshal(m, b)
 }
 func (m *RPCAddPeerRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_RPCAddPeerRequest.Marshal(b, m, deterministic)
 }
-func (m *RPCAddPeerRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_RPCAddPeerRequest.Merge(m, src)
+func (dst *RPCAddPeerRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RPCAddPeerRequest.Merge(dst, src)
 }
 func (m *RPCAddPeerRequest) XXX_Size() int {
 	return xxx_messageInfo_RPCAddPeerRequest.Size(m)
@@ -160,17 +158,16 @@ func (m *RPCSubscribeShardRequest) Reset()         { *m = RPCSubscribeShardReque
 func (m *RPCSubscribeShardRequest) String() string { return proto.CompactTextString(m) }
 func (*RPCSubscribeShardRequest) ProtoMessage()    {}
 func (*RPCSubscribeShardRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_77a6da22d6a3feb1, []int{3}
+	return fileDescriptor_rpc_65400171214530d0, []int{3}
 }
-
 func (m *RPCSubscribeShardRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RPCSubscribeShardRequest.Unmarshal(m, b)
 }
 func (m *RPCSubscribeShardRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_RPCSubscribeShardRequest.Marshal(b, m, deterministic)
 }
-func (m *RPCSubscribeShardRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_RPCSubscribeShardRequest.Merge(m, src)
+func (dst *RPCSubscribeShardRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RPCSubscribeShardRequest.Merge(dst, src)
 }
 func (m *RPCSubscribeShardRequest) XXX_Size() int {
 	return xxx_messageInfo_RPCSubscribeShardRequest.Size(m)
@@ -199,17 +196,16 @@ func (m *RPCUnsubscribeShardRequest) Reset()         { *m = RPCUnsubscribeShardR
 func (m *RPCUnsubscribeShardRequest) String() string { return proto.CompactTextString(m) }
 func (*RPCUnsubscribeShardRequest) ProtoMessage()    {}
 func (*RPCUnsubscribeShardRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_77a6da22d6a3feb1, []int{4}
+	return fileDescriptor_rpc_65400171214530d0, []int{4}
 }
-
 func (m *RPCUnsubscribeShardRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RPCUnsubscribeShardRequest.Unmarshal(m, b)
 }
 func (m *RPCUnsubscribeShardRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_RPCUnsubscribeShardRequest.Marshal(b, m, deterministic)
 }
-func (m *RPCUnsubscribeShardRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_RPCUnsubscribeShardRequest.Merge(m, src)
+func (dst *RPCUnsubscribeShardRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RPCUnsubscribeShardRequest.Merge(dst, src)
 }
 func (m *RPCUnsubscribeShardRequest) XXX_Size() int {
 	return xxx_messageInfo_RPCUnsubscribeShardRequest.Size(m)
@@ -237,17 +233,16 @@ func (m *RPCGetSubscribedShardRequest) Reset()         { *m = RPCGetSubscribedSh
 func (m *RPCGetSubscribedShardRequest) String() string { return proto.CompactTextString(m) }
 func (*RPCGetSubscribedShardRequest) ProtoMessage()    {}
 func (*RPCGetSubscribedShardRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_77a6da22d6a3feb1, []int{5}
+	return fileDescriptor_rpc_65400171214530d0, []int{5}
 }
-
 func (m *RPCGetSubscribedShardRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RPCGetSubscribedShardRequest.Unmarshal(m, b)
 }
 func (m *RPCGetSubscribedShardRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_RPCGetSubscribedShardRequest.Marshal(b, m, deterministic)
 }
-func (m *RPCGetSubscribedShardRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_RPCGetSubscribedShardRequest.Merge(m, src)
+func (dst *RPCGetSubscribedShardRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RPCGetSubscribedShardRequest.Merge(dst, src)
 }
 func (m *RPCGetSubscribedShardRequest) XXX_Size() int {
 	return xxx_messageInfo_RPCGetSubscribedShardRequest.Size(m)
@@ -269,17 +264,16 @@ func (m *RPCGetSubscribedShardResponse) Reset()         { *m = RPCGetSubscribedS
 func (m *RPCGetSubscribedShardResponse) String() string { return proto.CompactTextString(m) }
 func (*RPCGetSubscribedShardResponse) ProtoMessage()    {}
 func (*RPCGetSubscribedShardResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_77a6da22d6a3feb1, []int{6}
+	return fileDescriptor_rpc_65400171214530d0, []int{6}
 }
-
 func (m *RPCGetSubscribedShardResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RPCGetSubscribedShardResponse.Unmarshal(m, b)
 }
 func (m *RPCGetSubscribedShardResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_RPCGetSubscribedShardResponse.Marshal(b, m, deterministic)
 }
-func (m *RPCGetSubscribedShardResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_RPCGetSubscribedShardResponse.Merge(m, src)
+func (dst *RPCGetSubscribedShardResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RPCGetSubscribedShardResponse.Merge(dst, src)
 }
 func (m *RPCGetSubscribedShardResponse) XXX_Size() int {
 	return xxx_messageInfo_RPCGetSubscribedShardResponse.Size(m)
@@ -311,17 +305,16 @@ func (m *RPCBroadcastCollationRequest) Reset()         { *m = RPCBroadcastCollat
 func (m *RPCBroadcastCollationRequest) String() string { return proto.CompactTextString(m) }
 func (*RPCBroadcastCollationRequest) ProtoMessage()    {}
 func (*RPCBroadcastCollationRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_77a6da22d6a3feb1, []int{7}
+	return fileDescriptor_rpc_65400171214530d0, []int{7}
 }
-
 func (m *RPCBroadcastCollationRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RPCBroadcastCollationRequest.Unmarshal(m, b)
 }
 func (m *RPCBroadcastCollationRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_RPCBroadcastCollationRequest.Marshal(b, m, deterministic)
 }
-func (m *RPCBroadcastCollationRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_RPCBroadcastCollationRequest.Merge(m, src)
+func (dst *RPCBroadcastCollationRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RPCBroadcastCollationRequest.Merge(dst, src)
 }
 func (m *RPCBroadcastCollationRequest) XXX_Size() int {
 	return xxx_messageInfo_RPCBroadcastCollationRequest.Size(m)
@@ -371,17 +364,16 @@ func (m *RPCSendCollationRequest) Reset()         { *m = RPCSendCollationRequest
 func (m *RPCSendCollationRequest) String() string { return proto.CompactTextString(m) }
 func (*RPCSendCollationRequest) ProtoMessage()    {}
 func (*RPCSendCollationRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_77a6da22d6a3feb1, []int{8}
+	return fileDescriptor_rpc_65400171214530d0, []int{8}
 }
-
 func (m *RPCSendCollationRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RPCSendCollationRequest.Unmarshal(m, b)
 }
 func (m *RPCSendCollationRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_RPCSendCollationRequest.Marshal(b, m, deterministic)
 }
-func (m *RPCSendCollationRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_RPCSendCollationRequest.Merge(m, src)
+func (dst *RPCSendCollationRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RPCSendCollationRequest.Merge(dst, src)
 }
 func (m *RPCSendCollationRequest) XXX_Size() int {
 	return xxx_messageInfo_RPCSendCollationRequest.Size(m)
@@ -409,17 +401,16 @@ func (m *RPCStopServerRequest) Reset()         { *m = RPCStopServerRequest{} }
 func (m *RPCStopServerRequest) String() string { return proto.CompactTextString(m) }
 func (*RPCStopServerRequest) ProtoMessage()    {}
 func (*RPCStopServerRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_77a6da22d6a3feb1, []int{9}
+	return fileDescriptor_rpc_65400171214530d0, []int{9}
 }
-
 func (m *RPCStopServerRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RPCStopServerRequest.Unmarshal(m, b)
 }
 func (m *RPCStopServerRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_RPCStopServerRequest.Marshal(b, m, deterministic)
 }
-func (m *RPCStopServerRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_RPCStopServerRequest.Merge(m, src)
+func (dst *RPCStopServerRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RPCStopServerRequest.Merge(dst, src)
 }
 func (m *RPCStopServerRequest) XXX_Size() int {
 	return xxx_messageInfo_RPCStopServerRequest.Size(m)
@@ -440,17 +431,16 @@ func (m *RPCPlainResponse) Reset()         { *m = RPCPlainResponse{} }
 func (m *RPCPlainResponse) String() string { return proto.CompactTextString(m) }
 func (*RPCPlainResponse) ProtoMessage()    {}
 func (*RPCPlainResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_77a6da22d6a3feb1, []int{10}
+	return fileDescriptor_rpc_65400171214530d0, []int{10}
 }
-
 func (m *RPCPlainResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RPCPlainResponse.Unmarshal(m, b)
 }
 func (m *RPCPlainResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_RPCPlainResponse.Marshal(b, m, deterministic)
 }
-func (m *RPCPlainResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_RPCPlainResponse.Merge(m, src)
+func (dst *RPCPlainResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RPCPlainResponse.Merge(dst, src)
 }
 func (m *RPCPlainResponse) XXX_Size() int {
 	return xxx_messageInfo_RPCPlainResponse.Size(m)
@@ -475,17 +465,16 @@ func (m *SendRequest) Reset()         { *m = SendRequest{} }
 func (m *SendRequest) String() string { return proto.CompactTextString(m) }
 func (*SendRequest) ProtoMessage()    {}
 func (*SendRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_77a6da22d6a3feb1, []int{11}
+	return fileDescriptor_rpc_65400171214530d0, []int{11}
 }
-
 func (m *SendRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SendRequest.Unmarshal(m, b)
 }
 func (m *SendRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_SendRequest.Marshal(b, m, deterministic)
 }
-func (m *SendRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_SendRequest.Merge(m, src)
+func (dst *SendRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SendRequest.Merge(dst, src)
 }
 func (m *SendRequest) XXX_Size() int {
 	return xxx_messageInfo_SendRequest.Size(m)
@@ -535,17 +524,16 @@ func (m *SendResponse) Reset()         { *m = SendResponse{} }
 func (m *SendResponse) String() string { return proto.CompactTextString(m) }
 func (*SendResponse) ProtoMessage()    {}
 func (*SendResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_77a6da22d6a3feb1, []int{12}
+	return fileDescriptor_rpc_65400171214530d0, []int{12}
 }
-
 func (m *SendResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SendResponse.Unmarshal(m, b)
 }
 func (m *SendResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_SendResponse.Marshal(b, m, deterministic)
 }
-func (m *SendResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_SendResponse.Merge(m, src)
+func (dst *SendResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SendResponse.Merge(dst, src)
 }
 func (m *SendResponse) XXX_Size() int {
 	return xxx_messageInfo_SendResponse.Size(m)
@@ -573,17 +561,16 @@ func (m *RPCListPeerRequest) Reset()         { *m = RPCListPeerRequest{} }
 func (m *RPCListPeerRequest) String() string { return proto.CompactTextString(m) }
 func (*RPCListPeerRequest) ProtoMessage()    {}
 func (*RPCListPeerRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_77a6da22d6a3feb1, []int{13}
+	return fileDescriptor_rpc_65400171214530d0, []int{13}
 }
-
 func (m *RPCListPeerRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RPCListPeerRequest.Unmarshal(m, b)
 }
 func (m *RPCListPeerRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_RPCListPeerRequest.Marshal(b, m, deterministic)
 }
-func (m *RPCListPeerRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_RPCListPeerRequest.Merge(m, src)
+func (dst *RPCListPeerRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RPCListPeerRequest.Merge(dst, src)
 }
 func (m *RPCListPeerRequest) XXX_Size() int {
 	return xxx_messageInfo_RPCListPeerRequest.Size(m)
@@ -605,17 +592,16 @@ func (m *RPCListPeerResponse) Reset()         { *m = RPCListPeerResponse{} }
 func (m *RPCListPeerResponse) String() string { return proto.CompactTextString(m) }
 func (*RPCListPeerResponse) ProtoMessage()    {}
 func (*RPCListPeerResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_77a6da22d6a3feb1, []int{14}
+	return fileDescriptor_rpc_65400171214530d0, []int{14}
 }
-
 func (m *RPCListPeerResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RPCListPeerResponse.Unmarshal(m, b)
 }
 func (m *RPCListPeerResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_RPCListPeerResponse.Marshal(b, m, deterministic)
 }
-func (m *RPCListPeerResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_RPCListPeerResponse.Merge(m, src)
+func (dst *RPCListPeerResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RPCListPeerResponse.Merge(dst, src)
 }
 func (m *RPCListPeerResponse) XXX_Size() int {
 	return xxx_messageInfo_RPCListPeerResponse.Size(m)
@@ -644,17 +630,16 @@ func (m *RPCListTopicPeerRequest) Reset()         { *m = RPCListTopicPeerRequest
 func (m *RPCListTopicPeerRequest) String() string { return proto.CompactTextString(m) }
 func (*RPCListTopicPeerRequest) ProtoMessage()    {}
 func (*RPCListTopicPeerRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_77a6da22d6a3feb1, []int{15}
+	return fileDescriptor_rpc_65400171214530d0, []int{15}
 }
-
 func (m *RPCListTopicPeerRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RPCListTopicPeerRequest.Unmarshal(m, b)
 }
 func (m *RPCListTopicPeerRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_RPCListTopicPeerRequest.Marshal(b, m, deterministic)
 }
-func (m *RPCListTopicPeerRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_RPCListTopicPeerRequest.Merge(m, src)
+func (dst *RPCListTopicPeerRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RPCListTopicPeerRequest.Merge(dst, src)
 }
 func (m *RPCListTopicPeerRequest) XXX_Size() int {
 	return xxx_messageInfo_RPCListTopicPeerRequest.Size(m)
@@ -683,17 +668,16 @@ func (m *RPCListTopicPeerResponse) Reset()         { *m = RPCListTopicPeerRespon
 func (m *RPCListTopicPeerResponse) String() string { return proto.CompactTextString(m) }
 func (*RPCListTopicPeerResponse) ProtoMessage()    {}
 func (*RPCListTopicPeerResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_77a6da22d6a3feb1, []int{16}
+	return fileDescriptor_rpc_65400171214530d0, []int{16}
 }
-
 func (m *RPCListTopicPeerResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RPCListTopicPeerResponse.Unmarshal(m, b)
 }
 func (m *RPCListTopicPeerResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_RPCListTopicPeerResponse.Marshal(b, m, deterministic)
 }
-func (m *RPCListTopicPeerResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_RPCListTopicPeerResponse.Merge(m, src)
+func (dst *RPCListTopicPeerResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RPCListTopicPeerResponse.Merge(dst, src)
 }
 func (m *RPCListTopicPeerResponse) XXX_Size() int {
 	return xxx_messageInfo_RPCListTopicPeerResponse.Size(m)
@@ -722,17 +706,16 @@ func (m *RPCRemovePeerRequest) Reset()         { *m = RPCRemovePeerRequest{} }
 func (m *RPCRemovePeerRequest) String() string { return proto.CompactTextString(m) }
 func (*RPCRemovePeerRequest) ProtoMessage()    {}
 func (*RPCRemovePeerRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_77a6da22d6a3feb1, []int{17}
+	return fileDescriptor_rpc_65400171214530d0, []int{17}
 }
-
 func (m *RPCRemovePeerRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RPCRemovePeerRequest.Unmarshal(m, b)
 }
 func (m *RPCRemovePeerRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_RPCRemovePeerRequest.Marshal(b, m, deterministic)
 }
-func (m *RPCRemovePeerRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_RPCRemovePeerRequest.Merge(m, src)
+func (dst *RPCRemovePeerRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RPCRemovePeerRequest.Merge(dst, src)
 }
 func (m *RPCRemovePeerRequest) XXX_Size() int {
 	return xxx_messageInfo_RPCRemovePeerRequest.Size(m)
@@ -746,6 +729,52 @@ var xxx_messageInfo_RPCRemovePeerRequest proto.InternalMessageInfo
 func (m *RPCRemovePeerRequest) GetPeerID() string {
 	if m != nil {
 		return m.PeerID
+	}
+	return ""
+}
+
+type RPCBootstrapRequest struct {
+	Flag                 bool     `protobuf:"varint,1,opt,name=flag,proto3" json:"flag,omitempty"`
+	BootnodesStr         string   `protobuf:"bytes,2,opt,name=bootnodesStr,proto3" json:"bootnodesStr,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *RPCBootstrapRequest) Reset()         { *m = RPCBootstrapRequest{} }
+func (m *RPCBootstrapRequest) String() string { return proto.CompactTextString(m) }
+func (*RPCBootstrapRequest) ProtoMessage()    {}
+func (*RPCBootstrapRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_rpc_65400171214530d0, []int{18}
+}
+func (m *RPCBootstrapRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_RPCBootstrapRequest.Unmarshal(m, b)
+}
+func (m *RPCBootstrapRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_RPCBootstrapRequest.Marshal(b, m, deterministic)
+}
+func (dst *RPCBootstrapRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RPCBootstrapRequest.Merge(dst, src)
+}
+func (m *RPCBootstrapRequest) XXX_Size() int {
+	return xxx_messageInfo_RPCBootstrapRequest.Size(m)
+}
+func (m *RPCBootstrapRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_RPCBootstrapRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_RPCBootstrapRequest proto.InternalMessageInfo
+
+func (m *RPCBootstrapRequest) GetFlag() bool {
+	if m != nil {
+		return m.Flag
+	}
+	return false
+}
+
+func (m *RPCBootstrapRequest) GetBootnodesStr() string {
+	if m != nil {
+		return m.BootnodesStr
 	}
 	return ""
 }
@@ -770,61 +799,7 @@ func init() {
 	proto.RegisterType((*RPCListTopicPeerResponse)(nil), "proto.rpc.RPCListTopicPeerResponse")
 	proto.RegisterMapType((map[string]*message.Peers)(nil), "proto.rpc.RPCListTopicPeerResponse.TopicPeersEntry")
 	proto.RegisterType((*RPCRemovePeerRequest)(nil), "proto.rpc.RPCRemovePeerRequest")
-}
-
-func init() { proto.RegisterFile("rpc.proto", fileDescriptor_77a6da22d6a3feb1) }
-
-var fileDescriptor_77a6da22d6a3feb1 = []byte{
-	// 769 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x54, 0x5f, 0x4f, 0xdb, 0x48,
-	0x10, 0x27, 0x09, 0x10, 0x32, 0x01, 0x8e, 0x5b, 0xa2, 0x60, 0xf9, 0x80, 0x43, 0x8b, 0x4e, 0x17,
-	0xdd, 0x1d, 0x8e, 0x2e, 0x48, 0x88, 0xbb, 0xbe, 0xb4, 0x0d, 0xfd, 0x83, 0xe0, 0xc1, 0xdd, 0x50,
-	0xa9, 0xaa, 0xfa, 0xe2, 0xd8, 0xab, 0xc4, 0x6a, 0x62, 0x6f, 0x77, 0x1d, 0x2a, 0x50, 0x3f, 0x5e,
-	0x3f, 0x4a, 0x3f, 0x48, 0xb5, 0xeb, 0xb5, 0x63, 0x3b, 0xb1, 0xd2, 0x3e, 0xd9, 0x33, 0x3b, 0xf3,
-	0x9b, 0x9d, 0xdf, 0xcc, 0xfe, 0xa0, 0xc1, 0x99, 0x6b, 0x31, 0x1e, 0x46, 0x21, 0x6a, 0xa8, 0x8f,
-	0xc5, 0x99, 0x6b, 0x3e, 0x1d, 0xf9, 0xd1, 0x78, 0x36, 0xb4, 0xdc, 0x70, 0xda, 0xa5, 0xd1, 0x98,
-	0x53, 0x41, 0x1d, 0xee, 0x8e, 0xbb, 0x62, 0xec, 0x70, 0xcf, 0x0f, 0x46, 0x67, 0xac, 0xc7, 0xce,
-	0x58, 0xe8, 0x76, 0xd9, 0xb0, 0x3b, 0xa5, 0x42, 0x38, 0x23, 0x9a, 0x7c, 0x63, 0x30, 0xbc, 0x0f,
-	0xbf, 0x12, 0xbb, 0x3f, 0x18, 0x87, 0x9f, 0xed, 0xeb, 0x2b, 0x42, 0x3f, 0xcd, 0xa8, 0x88, 0xf0,
-	0x3f, 0x80, 0xb2, 0x4e, 0xc1, 0xc2, 0x40, 0x50, 0xd4, 0x86, 0x4d, 0x46, 0x29, 0xbf, 0xbe, 0x32,
-	0x2a, 0x27, 0x95, 0x4e, 0x83, 0x68, 0x0b, 0xdf, 0x28, 0x88, 0x67, 0x9e, 0x67, 0x53, 0xca, 0x35,
-	0x04, 0xda, 0x85, 0xaa, 0xcf, 0x74, 0x60, 0xd5, 0x67, 0x08, 0xc1, 0x3a, 0x0b, 0x79, 0x64, 0x54,
-	0x4f, 0x2a, 0x9d, 0x1a, 0x51, 0xff, 0xd2, 0x27, 0x28, 0xf5, 0x8c, 0x5a, 0xec, 0x93, 0xff, 0xf8,
-	0x02, 0x0c, 0x59, 0x7a, 0x36, 0x14, 0x2e, 0xf7, 0x87, 0x74, 0x20, 0x1b, 0x49, 0x30, 0x4d, 0xd8,
-	0x52, 0x8d, 0x5d, 0x5f, 0x09, 0xa3, 0x72, 0x52, 0xeb, 0xd4, 0x48, 0x6a, 0xe3, 0x4b, 0x30, 0x89,
-	0xdd, 0x7f, 0x1b, 0x88, 0x9f, 0xce, 0x3c, 0x86, 0x43, 0x62, 0xf7, 0x5f, 0xd1, 0x28, 0x2d, 0xea,
-	0x65, 0x73, 0xf1, 0x13, 0x38, 0x2a, 0x39, 0xd7, 0xbc, 0x64, 0xc1, 0xab, 0x05, 0xf0, 0x2f, 0x0a,
-	0xfc, 0x39, 0x0f, 0x1d, 0xcf, 0x75, 0x44, 0xd4, 0x0f, 0x27, 0x13, 0x27, 0xf2, 0xc3, 0x20, 0xb9,
-	0x98, 0x01, 0x75, 0x1d, 0xab, 0xb8, 0xaa, 0x91, 0xc4, 0x94, 0x6c, 0x07, 0xb3, 0xe9, 0x90, 0x72,
-	0x4d, 0x99, 0xb6, 0x14, 0x69, 0xfe, 0x23, 0x4d, 0x49, 0xf3, 0x1f, 0xf5, 0x64, 0xb8, 0x1f, 0x7a,
-	0xc6, 0x7a, 0x1c, 0x1b, 0x5b, 0xf8, 0x0d, 0x1c, 0x48, 0x32, 0x69, 0xe0, 0x2d, 0x14, 0xbe, 0x80,
-	0x86, 0x9b, 0xf8, 0x54, 0xe9, 0x66, 0xcf, 0x88, 0x57, 0xc2, 0x4a, 0x16, 0x64, 0x9e, 0x33, 0x0f,
-	0xc5, 0x6d, 0x68, 0x49, 0xc8, 0x28, 0x64, 0x03, 0xca, 0xef, 0xd3, 0x79, 0x63, 0x04, 0x7b, 0xc4,
-	0xee, 0xdb, 0x13, 0xc7, 0x0f, 0x12, 0x62, 0xb0, 0x0f, 0x4d, 0x59, 0x3b, 0x29, 0x59, 0xb2, 0x3f,
-	0xa8, 0x05, 0x1b, 0x51, 0xc8, 0x7c, 0x57, 0x35, 0xda, 0x20, 0xb1, 0x21, 0x99, 0x99, 0x8a, 0xd1,
-	0xdd, 0x03, 0x4b, 0x5a, 0x4d, 0x4c, 0xc9, 0x80, 0xe7, 0x44, 0x8e, 0xea, 0x75, 0x9b, 0xa8, 0x7f,
-	0x8c, 0x61, 0x3b, 0x2e, 0xa5, 0x67, 0x92, 0xc4, 0x54, 0x33, 0x31, 0x2d, 0xb5, 0xd5, 0xb7, 0xbe,
-	0x88, 0x32, 0x8b, 0x8a, 0xff, 0x86, 0xfd, 0x9c, 0x57, 0x03, 0xb4, 0x60, 0x43, 0x5e, 0x2f, 0x9e,
-	0x68, 0x83, 0xc4, 0x06, 0xfe, 0x57, 0x11, 0x2a, 0x83, 0xef, 0xe4, 0x25, 0xb3, 0x0b, 0xdf, 0x86,
-	0x4d, 0x75, 0xf1, 0x78, 0xc1, 0x1a, 0x44, 0x5b, 0xf8, 0x6b, 0x45, 0x6d, 0x74, 0x21, 0x47, 0x57,
-	0x19, 0x00, 0x44, 0x89, 0x33, 0x2e, 0xd5, 0xec, 0x9d, 0x5b, 0xe9, 0xfb, 0xb6, 0xca, 0x12, 0xad,
-	0xd4, 0x23, 0x5e, 0x04, 0x11, 0x7f, 0x20, 0x19, 0x18, 0x73, 0x00, 0xbf, 0x14, 0x8e, 0xd1, 0x1e,
-	0xd4, 0x3e, 0xd2, 0x07, 0xcd, 0xbb, 0xfc, 0x45, 0x7f, 0xc1, 0xc6, 0xbd, 0x33, 0x99, 0x51, 0xc5,
-	0x50, 0xb3, 0xd7, 0x2a, 0xcc, 0x5e, 0xe5, 0x92, 0x38, 0xe4, 0xff, 0xea, 0x65, 0x05, 0x5b, 0x6a,
-	0xee, 0x84, 0x4e, 0xc3, 0x7b, 0x5a, 0x68, 0x7b, 0xd9, 0x50, 0x7b, 0xdf, 0xea, 0x50, 0xb3, 0x43,
-	0x17, 0xbd, 0x86, 0xba, 0xd6, 0x11, 0x74, 0x98, 0x6f, 0x2c, 0xaf, 0x39, 0xe6, 0x51, 0xc9, 0xa9,
-	0xde, 0xa5, 0x35, 0xf4, 0x12, 0xea, 0x5a, 0x63, 0x8a, 0x48, 0x79, 0xe9, 0x31, 0x7f, 0xcb, 0x9f,
-	0xe6, 0x77, 0x72, 0x0d, 0xdd, 0xc1, 0x6e, 0x5e, 0x5e, 0xd0, 0x69, 0xa1, 0xf4, 0x32, 0x09, 0x59,
-	0x85, 0xfa, 0x0e, 0xf6, 0x8a, 0xe2, 0x83, 0xfe, 0xc8, 0xa7, 0x94, 0x88, 0xd3, 0x2a, 0x64, 0x1f,
-	0xd0, 0xa2, 0xf8, 0xa0, 0x3f, 0xf3, 0x49, 0xa5, 0xf2, 0x65, 0x76, 0x56, 0x07, 0xa6, 0xa5, 0x3e,
-	0x00, 0x5a, 0x94, 0xaa, 0x62, 0xa9, 0x52, 0x31, 0x5b, 0xd5, 0x08, 0x81, 0x9d, 0x9c, 0x14, 0x21,
-	0x5c, 0xe0, 0x7d, 0x89, 0x4e, 0xad, 0xc2, 0xbc, 0x05, 0x98, 0x6b, 0x11, 0xfa, 0xbd, 0x00, 0x58,
-	0x54, 0xa9, 0x55, 0x68, 0xff, 0xc1, 0xba, 0xbc, 0x04, 0x6a, 0x67, 0xc2, 0x32, 0x0a, 0x66, 0x1e,
-	0x2c, 0xf8, 0xd3, 0xd4, 0x1b, 0xd8, 0x4a, 0x34, 0x04, 0x1d, 0x2d, 0xbe, 0xe0, 0xec, 0x7e, 0x1e,
-	0x97, 0x1d, 0xa7, 0x60, 0xef, 0x61, 0x27, 0xf7, 0xec, 0x8b, 0x4c, 0x2d, 0x13, 0x20, 0xf3, 0xf4,
-	0x07, 0x74, 0x23, 0x66, 0x6c, 0xfe, 0x8a, 0x8b, 0x8c, 0x2d, 0xbc, 0xef, 0x15, 0x8c, 0x0d, 0x37,
-	0xd5, 0xe9, 0xf9, 0xf7, 0x00, 0x00, 0x00, 0xff, 0xff, 0x7e, 0xd5, 0x53, 0x4e, 0x9f, 0x08, 0x00,
-	0x00,
+	proto.RegisterType((*RPCBootstrapRequest)(nil), "proto.rpc.RPCBootstrapRequest")
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -851,6 +826,7 @@ type PocClient interface {
 	ListPeer(ctx context.Context, in *RPCListPeerRequest, opts ...grpc.CallOption) (*RPCListPeerResponse, error)
 	ListTopicPeer(ctx context.Context, in *RPCListTopicPeerRequest, opts ...grpc.CallOption) (*RPCListTopicPeerResponse, error)
 	RemovePeer(ctx context.Context, in *RPCRemovePeerRequest, opts ...grpc.CallOption) (*RPCPlainResponse, error)
+	Bootstrap(ctx context.Context, in *RPCBootstrapRequest, opts ...grpc.CallOption) (*RPCPlainResponse, error)
 }
 
 type pocClient struct {
@@ -969,6 +945,15 @@ func (c *pocClient) RemovePeer(ctx context.Context, in *RPCRemovePeerRequest, op
 	return out, nil
 }
 
+func (c *pocClient) Bootstrap(ctx context.Context, in *RPCBootstrapRequest, opts ...grpc.CallOption) (*RPCPlainResponse, error) {
+	out := new(RPCPlainResponse)
+	err := c.cc.Invoke(ctx, "/proto.rpc.Poc/Bootstrap", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // PocServer is the server API for Poc service.
 type PocServer interface {
 	ShowPID(context.Context, *RPCShowPIDRequest) (*RPCShowPIDResponse, error)
@@ -983,6 +968,7 @@ type PocServer interface {
 	ListPeer(context.Context, *RPCListPeerRequest) (*RPCListPeerResponse, error)
 	ListTopicPeer(context.Context, *RPCListTopicPeerRequest) (*RPCListTopicPeerResponse, error)
 	RemovePeer(context.Context, *RPCRemovePeerRequest) (*RPCPlainResponse, error)
+	Bootstrap(context.Context, *RPCBootstrapRequest) (*RPCPlainResponse, error)
 }
 
 func RegisterPocServer(s *grpc.Server, srv PocServer) {
@@ -1205,6 +1191,24 @@ func _Poc_RemovePeer_Handler(srv interface{}, ctx context.Context, dec func(inte
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Poc_Bootstrap_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RPCBootstrapRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(PocServer).Bootstrap(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/proto.rpc.Poc/Bootstrap",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(PocServer).Bootstrap(ctx, req.(*RPCBootstrapRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _Poc_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "proto.rpc.Poc",
 	HandlerType: (*PocServer)(nil),
@@ -1257,7 +1261,69 @@ var _Poc_serviceDesc = grpc.ServiceDesc{
 			MethodName: "RemovePeer",
 			Handler:    _Poc_RemovePeer_Handler,
 		},
+		{
+			MethodName: "Bootstrap",
+			Handler:    _Poc_Bootstrap_Handler,
+		},
 	},
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "rpc.proto",
+}
+
+func init() { proto.RegisterFile("rpc.proto", fileDescriptor_rpc_65400171214530d0) }
+
+var fileDescriptor_rpc_65400171214530d0 = []byte{
+	// 817 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x54, 0x6d, 0x8f, 0xdb, 0x44,
+	0x10, 0x6e, 0x92, 0x7b, 0x89, 0x27, 0xd7, 0x72, 0x6c, 0xa3, 0xd4, 0x32, 0xbd, 0x72, 0xda, 0x0a,
+	0x11, 0x01, 0x75, 0x44, 0x2a, 0x55, 0x05, 0xbe, 0x40, 0x73, 0xbc, 0x1c, 0x2d, 0x92, 0xd9, 0x1c,
+	0x12, 0x42, 0x7c, 0x71, 0xec, 0x25, 0xb1, 0x48, 0xbc, 0xcb, 0xee, 0xe6, 0xd0, 0x55, 0xfc, 0x28,
+	0x7e, 0x04, 0x3f, 0x0c, 0x79, 0xbd, 0x76, 0xec, 0x4d, 0x2c, 0xc3, 0x27, 0xef, 0xcc, 0xce, 0x3c,
+	0xb3, 0xf3, 0xcc, 0xf8, 0x01, 0x47, 0xf0, 0xc8, 0xe7, 0x82, 0x29, 0x86, 0x1c, 0xfd, 0xf1, 0x05,
+	0x8f, 0xbc, 0x2f, 0x97, 0x89, 0x5a, 0x6d, 0x17, 0x7e, 0xc4, 0x36, 0x13, 0xaa, 0x56, 0x82, 0x4a,
+	0x1a, 0x8a, 0x68, 0x35, 0x91, 0xab, 0x50, 0xc4, 0x49, 0xba, 0x7c, 0xc6, 0xa7, 0xfc, 0x19, 0x67,
+	0xd1, 0x84, 0x2f, 0x26, 0x1b, 0x2a, 0x65, 0xb8, 0xa4, 0xc5, 0x37, 0x07, 0xc3, 0x0f, 0xe1, 0x5d,
+	0x12, 0xcc, 0xe6, 0x2b, 0xf6, 0x67, 0x70, 0x7d, 0x45, 0xe8, 0x1f, 0x5b, 0x2a, 0x15, 0xfe, 0x04,
+	0x50, 0xd5, 0x29, 0x39, 0x4b, 0x25, 0x45, 0x23, 0x38, 0xe1, 0x94, 0x8a, 0xeb, 0x2b, 0xb7, 0x73,
+	0xd9, 0x19, 0x3b, 0xc4, 0x58, 0xf8, 0xb5, 0x86, 0xf8, 0x2a, 0x8e, 0x03, 0x4a, 0x85, 0x81, 0x40,
+	0x0f, 0xa0, 0x9b, 0x70, 0x13, 0xd8, 0x4d, 0x38, 0x42, 0x70, 0xc4, 0x99, 0x50, 0x6e, 0xf7, 0xb2,
+	0x33, 0xee, 0x11, 0x7d, 0xce, 0x7c, 0x92, 0xd2, 0xd8, 0xed, 0xe5, 0xbe, 0xec, 0x8c, 0x5f, 0x80,
+	0x9b, 0x95, 0xde, 0x2e, 0x64, 0x24, 0x92, 0x05, 0x9d, 0x67, 0x8d, 0x14, 0x98, 0x1e, 0xf4, 0x75,
+	0x63, 0xd7, 0x57, 0xd2, 0xed, 0x5c, 0xf6, 0xc6, 0x3d, 0x52, 0xda, 0xf8, 0x25, 0x78, 0x24, 0x98,
+	0xfd, 0x94, 0xca, 0xff, 0x9d, 0xf9, 0x04, 0x1e, 0x93, 0x60, 0xf6, 0x2d, 0x55, 0x65, 0xd1, 0xb8,
+	0x9a, 0x8b, 0xbf, 0x80, 0x8b, 0x86, 0x7b, 0xc3, 0x4b, 0x15, 0xbc, 0x6b, 0x81, 0xff, 0xa5, 0xc1,
+	0x5f, 0x09, 0x16, 0xc6, 0x51, 0x28, 0xd5, 0x8c, 0xad, 0xd7, 0xa1, 0x4a, 0x58, 0x5a, 0x3c, 0xcc,
+	0x85, 0x53, 0x13, 0xab, 0xb9, 0xea, 0x91, 0xc2, 0xcc, 0xd8, 0x4e, 0xb7, 0x9b, 0x05, 0x15, 0x86,
+	0x32, 0x63, 0x69, 0xd2, 0x92, 0xb7, 0xb4, 0x24, 0x2d, 0x79, 0x6b, 0x26, 0x23, 0x12, 0x16, 0xbb,
+	0x47, 0x79, 0x6c, 0x6e, 0xe1, 0x1f, 0xe1, 0x51, 0x46, 0x26, 0x4d, 0xe3, 0xbd, 0xc2, 0x2f, 0xc0,
+	0x89, 0x0a, 0x9f, 0x2e, 0x3d, 0x98, 0xba, 0xf9, 0x4a, 0xf8, 0xc5, 0x82, 0xec, 0x72, 0x76, 0xa1,
+	0x78, 0x04, 0xc3, 0x0c, 0x52, 0x31, 0x3e, 0xa7, 0xe2, 0xb6, 0x9c, 0x37, 0x46, 0x70, 0x4e, 0x82,
+	0x59, 0xb0, 0x0e, 0x93, 0xb4, 0x20, 0x06, 0x27, 0x30, 0xc8, 0x6a, 0x17, 0x25, 0x1b, 0xf6, 0x07,
+	0x0d, 0xe1, 0x58, 0x31, 0x9e, 0x44, 0xba, 0x51, 0x87, 0xe4, 0x46, 0xc6, 0xcc, 0x46, 0x2e, 0x6f,
+	0xee, 0x78, 0xd1, 0x6a, 0x61, 0x66, 0x0c, 0xc4, 0xa1, 0x0a, 0x75, 0xaf, 0x67, 0x44, 0x9f, 0x31,
+	0x86, 0xb3, 0xbc, 0x94, 0x99, 0x49, 0x11, 0xd3, 0xad, 0xc4, 0x0c, 0xf5, 0x56, 0xbf, 0x49, 0xa4,
+	0xaa, 0x2c, 0x2a, 0xfe, 0x18, 0x1e, 0xd6, 0xbc, 0x06, 0x60, 0x08, 0xc7, 0xd9, 0xf3, 0xf2, 0x89,
+	0x3a, 0x24, 0x37, 0xf0, 0xa7, 0x9a, 0xd0, 0x2c, 0xf8, 0x26, 0x7b, 0x64, 0x75, 0xe1, 0x47, 0x70,
+	0xa2, 0x1f, 0x9e, 0x2f, 0x98, 0x43, 0x8c, 0x85, 0xff, 0xe9, 0xe8, 0x8d, 0xb6, 0x72, 0x4c, 0x95,
+	0x39, 0x80, 0x2a, 0x9c, 0x79, 0xa9, 0xc1, 0xf4, 0xb9, 0x5f, 0xfe, 0xdf, 0x7e, 0x53, 0xa2, 0x5f,
+	0x7a, 0xe4, 0xd7, 0xa9, 0x12, 0x77, 0xa4, 0x02, 0xe3, 0xcd, 0xe1, 0x1d, 0xeb, 0x1a, 0x9d, 0x43,
+	0xef, 0x77, 0x7a, 0x67, 0x78, 0xcf, 0x8e, 0xe8, 0x23, 0x38, 0xbe, 0x0d, 0xd7, 0x5b, 0xaa, 0x19,
+	0x1a, 0x4c, 0x87, 0xd6, 0xec, 0x75, 0x2e, 0xc9, 0x43, 0x3e, 0xef, 0xbe, 0xec, 0x60, 0x5f, 0xcf,
+	0x9d, 0xd0, 0x0d, 0xbb, 0xa5, 0x56, 0xdb, 0x07, 0x45, 0xe1, 0x07, 0x4d, 0xeb, 0x2b, 0xc6, 0x94,
+	0x54, 0x22, 0xe4, 0x45, 0x38, 0x82, 0xa3, 0xdf, 0xd6, 0xe1, 0x52, 0x07, 0xf7, 0x89, 0x3e, 0x23,
+	0x0c, 0x67, 0x0b, 0xc6, 0x54, 0xca, 0x62, 0x2a, 0xe7, 0x4a, 0x98, 0x35, 0xa8, 0xf9, 0xa6, 0x7f,
+	0xf7, 0xa1, 0x17, 0xb0, 0x08, 0x7d, 0x07, 0xa7, 0x46, 0x96, 0xd0, 0xe3, 0x3a, 0x4f, 0x75, 0x09,
+	0xf3, 0x2e, 0x1a, 0x6e, 0xcd, 0x6a, 0xde, 0x43, 0xdf, 0xc0, 0xa9, 0x91, 0x2c, 0x1b, 0xa9, 0xae,
+	0x64, 0xde, 0x7b, 0xf5, 0xdb, 0xfa, 0x8a, 0xdf, 0x43, 0x37, 0xf0, 0xa0, 0xae, 0x56, 0xe8, 0xa9,
+	0x55, 0xfa, 0x90, 0x22, 0xb5, 0xa1, 0xfe, 0x0c, 0xe7, 0xb6, 0x96, 0xa1, 0x0f, 0xea, 0x29, 0x0d,
+	0x5a, 0xd7, 0x86, 0x9c, 0x00, 0xda, 0xd7, 0x32, 0xf4, 0x61, 0x3d, 0xa9, 0x51, 0x0d, 0xbd, 0x71,
+	0x7b, 0x60, 0x59, 0xea, 0x57, 0x40, 0xfb, 0xca, 0x67, 0x97, 0x6a, 0xd4, 0xc6, 0xb6, 0x46, 0x08,
+	0xdc, 0xaf, 0x29, 0x1b, 0xc2, 0x16, 0xef, 0x07, 0x64, 0xaf, 0x0d, 0xf3, 0x0d, 0xc0, 0x4e, 0xda,
+	0xd0, 0xfb, 0x16, 0xa0, 0x2d, 0x7a, 0x6d, 0x68, 0x9f, 0xc1, 0x51, 0xf6, 0x08, 0x34, 0xaa, 0x84,
+	0x55, 0x04, 0xd1, 0x7b, 0xb4, 0xe7, 0x2f, 0x53, 0x5f, 0x43, 0xbf, 0x90, 0x24, 0x74, 0xb1, 0x2f,
+	0x08, 0xd5, 0xfd, 0x7c, 0xd2, 0x74, 0x5d, 0x82, 0xfd, 0x02, 0xf7, 0x6b, 0x2a, 0x62, 0x33, 0x75,
+	0x48, 0xcf, 0xbc, 0xa7, 0xff, 0x41, 0x86, 0x72, 0xc6, 0x76, 0xa2, 0x60, 0x33, 0xb6, 0x27, 0x17,
+	0x6d, 0x8c, 0x7d, 0x0f, 0x4e, 0x29, 0x19, 0xc8, 0x6a, 0xcc, 0xd6, 0x92, 0x16, 0xac, 0xc5, 0x89,
+	0xbe, 0x7d, 0xfe, 0x6f, 0x00, 0x00, 0x00, 0xff, 0xff, 0x7b, 0x75, 0xb7, 0xe4, 0x3a, 0x09, 0x00,
+	0x00,
 }

--- a/pb/rpc/rpc.proto
+++ b/pb/rpc/rpc.proto
@@ -17,6 +17,7 @@ service Poc {
   rpc ListPeer(RPCListPeerRequest) returns (RPCListPeerResponse) {}
   rpc ListTopicPeer(RPCListTopicPeerRequest) returns (RPCListTopicPeerResponse) {}
   rpc RemovePeer(RPCRemovePeerRequest) returns (RPCPlainResponse) {}
+  rpc Bootstrap(RPCBootstrapRequest) returns (RPCPlainResponse) {}
 }
 
 // Request
@@ -89,4 +90,9 @@ message RPCListTopicPeerResponse {
 
 message RPCRemovePeerRequest {
   string peerID = 1;
+}
+
+message RPCBootstrapRequest {
+  bool flag = 1;
+  string bootnodesStr = 2;
 }

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -431,7 +431,6 @@ func (s *server) RemovePeer(
 func (s *server) Bootstrap(
 	ctx context.Context,
 	req *pbrpc.RPCBootstrapRequest) (*pbrpc.RPCPlainResponse, error) {
-	// Add span for RemovePeer
 	spanctx, err := logger.StartFromParentState(ctx, "RPCServer.Bootstrap", s.serializedSpanCtx)
 	if err != nil {
 		logger.Debugf("Failed to deserialze the trace context. Tracer won't be able to put rpc call traces together. err: %v", err)

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -84,7 +85,7 @@ func (s *server) AddPeer(
 	}
 	defer logger.Finish(spanctx)
 
-	logger.Debugf("rpcserver:AddPeer: receive=%v", req)
+	logger.Debugf("rpcserver:AddPeer: ip=%v, port=%v, seed=%v", req.Ip, req.Port, req.Seed)
 	_, targetPID, err := makeKey(int(req.Seed))
 	mAddr := fmt.Sprintf(
 		"/ip4/%s/tcp/%d/ipfs/%s",
@@ -133,7 +134,7 @@ func (s *server) SubscribeShard(
 	defer logger.Finish(spanctx)
 
 	subscribedShardID := make([]int64, 0)
-	logger.Debugf("rpcserver:SubscribeShardRequest: receive=%v", req)
+	logger.Debugf("rpcserver:SubscribeShard: shardIDs=%v", req.ShardIDs)
 	for _, shardID := range req.ShardIDs {
 		if err := s.node.ListenShard(spanctx, shardID); err != nil {
 			logger.SetErr(spanctx, fmt.Errorf("Failed to listen to shard %v", shardID))
@@ -161,7 +162,7 @@ func (s *server) UnsubscribeShard(
 	defer logger.Finish(spanctx)
 
 	unsubscribedShardID := make([]int64, 0)
-	logger.Debugf("rpcserver:UnsubscribeShardRequest: receive=%v", req)
+	logger.Debugf("rpcserver:UnsubscribeShard: shardIDs=%v", req.ShardIDs)
 	for _, shardID := range req.ShardIDs {
 		if err := s.node.UnlistenShard(spanctx, shardID); err != nil {
 			logger.SetErr(spanctx, fmt.Errorf("Failed to unlisten shard %v", shardID))
@@ -188,7 +189,7 @@ func (s *server) GetSubscribedShard(
 	}
 	defer logger.Finish(spanctx)
 
-	logger.Debugf("rpcserver:GetSubscribedShard: receive=%v", req)
+	logger.Debug("rpcserver:GetSubscribedShard")
 	shardIDs := s.node.GetListeningShards()
 	res := &pbrpc.RPCGetSubscribedShardResponse{
 		ShardIDs: shardIDs,
@@ -265,8 +266,12 @@ func (s *server) SendCollation(
 	}
 	defer logger.Finish(spanctx)
 
-	logger.Debugf("rpcserver:SendCollationRequest: receive=%v", req)
 	collation := req.Collation
+	logger.Debugf(
+		"rpcserver:SendCollationRequest: shardID=%v, period=%v",
+		collation.ShardID,
+		collation.Period,
+	)
 	err = s.node.broadcastCollationMessage(collation)
 	if err != nil {
 		errMsg := fmt.Errorf("Failed to broadcast collation message, err: %v", err)
@@ -293,7 +298,7 @@ func (s *server) StopServer(
 	}
 	defer logger.Finish(spanctx)
 
-	logger.Debugf("rpcserver:StopServer: receive=%v", req)
+	logger.Debug("rpcserver:StopServer")
 	go func() {
 		time.Sleep(time.Second * 1)
 		logger.Info("Closing RPC server by rpc call...")
@@ -314,7 +319,7 @@ func (s *server) Send(ctx context.Context, req *pbrpc.SendRequest) (*pbrpc.SendR
 	}
 	defer logger.Finish(spanctx)
 
-	logger.Debugf("rpcserver:Send: receive=%v", req)
+	logger.Debugf("rpcserver:Send: msgType=%v, data=%v", req.MsgType, req.Data)
 	if req.PeerID == "" {
 		typedMessage := &pbmsg.MessageWithType{
 			MsgType: req.MsgType,
@@ -363,7 +368,7 @@ func (s *server) Send(ctx context.Context, req *pbrpc.SendRequest) (*pbrpc.SendR
 func (s *server) ListPeer(
 	ctx context.Context,
 	req *pbrpc.RPCListPeerRequest) (*pbrpc.RPCListPeerResponse, error) {
-	logger.Debugf("rpcserver:ListPeer: receive=%v", req)
+	logger.Debug("rpcserver:ListPeer")
 	peerIDs := s.node.Network().Peers()
 	return &pbrpc.RPCListPeerResponse{
 		Peers: peerIDsToPeersString(peerIDs),
@@ -373,7 +378,7 @@ func (s *server) ListPeer(
 func (s *server) ListTopicPeer(
 	ctx context.Context,
 	req *pbrpc.RPCListTopicPeerRequest) (*pbrpc.RPCListTopicPeerResponse, error) {
-	logger.Debugf("rpcserver:ListTopicPeer: receive=%v", req)
+	logger.Debugf("rpcserver:ListTopicPeer: topics=%v", req.Topics)
 	var topics []string
 	if len(req.Topics) == 0 {
 		topics = s.node.pubsubService.GetTopics()
@@ -401,7 +406,7 @@ func (s *server) RemovePeer(
 	}
 	defer logger.Finish(spanctx)
 
-	logger.Debugf("rpcserver:RemovePeer: receive=%v", req)
+	logger.Debugf("rpcserver:RemovePeer: peerID=%v", req.PeerID)
 
 	peerID, err := stringToPeerID(req.PeerID)
 	if err != nil {
@@ -420,6 +425,53 @@ func (s *server) RemovePeer(
 
 	// TODO: consider the record in Peerstore
 	logger.Debug("rpcserver:RemovePeer: finished")
+	return &pbrpc.RPCPlainResponse{}, nil
+}
+
+func (s *server) Bootstrap(
+	ctx context.Context,
+	req *pbrpc.RPCBootstrapRequest) (*pbrpc.RPCPlainResponse, error) {
+	// Add span for RemovePeer
+	spanctx, err := logger.StartFromParentState(ctx, "RPCServer.Bootstrap", s.serializedSpanCtx)
+	if err != nil {
+		logger.Debugf("Failed to deserialze the trace context. Tracer won't be able to put rpc call traces together. err: %v", err)
+		spanctx = logger.Start(ctx, "RPCServer.Bootstrap")
+	}
+	defer logger.Finish(spanctx)
+
+	logger.Debugf("rpcserver:Bootstrap: flag=%v, bootnodes=%v", req.Flag, req.BootnodesStr)
+	if req.Flag {
+		var bootnodes = []pstore.PeerInfo{}
+		bootnodes, err = convertPeers(strings.Split(req.BootnodesStr, ","))
+		if err != nil {
+			errMsg := fmt.Errorf(
+				"failed to convert bootnode address: %v, to peer info format, err: %v",
+				req.BootnodesStr,
+				err,
+			)
+			logger.FinishWithErr(spanctx, errMsg)
+			logger.Error(errMsg.Error())
+			return nil, errMsg
+		}
+		err = s.node.StartBootstrapping(s.node.ctx, bootnodes)
+		if err != nil {
+			errMsg := fmt.Errorf("failed to start bootstrapping: %v", err)
+			logger.FinishWithErr(spanctx, errMsg)
+			logger.Error(errMsg.Error())
+			return nil, errMsg
+		}
+		logger.Debug("rpcserver:Bootstrap: started bootstrapping")
+	} else {
+		err = s.node.StopBootstrapping()
+		if err != nil {
+			errMsg := fmt.Errorf("failed to stop bootstrapping: %v", err)
+			logger.FinishWithErr(spanctx, errMsg)
+			logger.Error(errMsg.Error())
+			return nil, errMsg
+		}
+		logger.Debug("rpcserver:Bootstrap: stopped bootstrapping")
+	}
+	logger.Debug("rpcserver:Bootstrap: finished")
 	return &pbrpc.RPCPlainResponse{}, nil
 }
 


### PR DESCRIPTION
### What was wrong?
As described in https://github.com/ethresearch/sharding-p2p-poc/issues/108

### How was it fixed?
bootstrap start
```bash
# start bootstrapping with the bootnodes specified in the string 
$ sharding-p2p-poc -client bootstrap start bootnodeStr1,bootnodeStr2,...
# example
$ sharding-p2p-poc -rpcport=13002 -client bootstrap start `/ip4/127.0.0.1/tcp/10000/ipfs/QmS5QmciTXXnCUCyxud5eWFenUMAmvAWSDa1c7dvdXRMZ7,/ip4/127.0.0.1/tcp/10001/ipfs/QmexAnfpHrhMmAC5UNQVS8iBuUUgDrMbMY17Cck2gKrqeX`
```

bootstrap stop
```bash
# start bootstrapping with the bootnodes specified in the string 
$ sharding-p2p-poc -client bootstrap stop
```

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.imgur.com/ETxT4HP.jpg)
