### PR TITLE
Replace log level with verbose flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Usage of ./sharding-p2p-poc:
     	rpc port listened by the rpc server (default 13000)
   -seed int
     	set random seed for id generation
+  -verbose
+        set the log level to DEBUG, i.e., print all messages
 ```
 **Note**: `-bootstrap` controls whether to spin up a bootstrap routine, which periodically queries its peers for new peers. There will be no effect if you feed `-bootnodes` without specifying the flag `-bootstrap`.
 ### Example

--- a/cli-example/common.sh
+++ b/cli-example/common.sh
@@ -5,7 +5,6 @@ EXE_NAME="./sharding-p2p-poc"
 IP=127.0.0.1
 PORT=10000
 RPCPORT=13000
-LOGLEVEL="DEBUG"
 
 # show_port {seed}
 show_port() {
@@ -24,7 +23,7 @@ spinup_node() {
     rpcport=$(show_rpcport $seed)
     p=$@
     params=${@:2}
-    $EXE_NAME -seed=$seed -port=$port -rpcport=$rpcport -loglevel=$LOGLEVEL $params &
+    $EXE_NAME -seed=$seed -port=$port -rpcport=$rpcport -verbose $params &
 }
 
 cli_prompt() {

--- a/deployment/ansible/roles/common/tasks/cli_getsubshard.yml
+++ b/deployment/ansible/roles/common/tasks/cli_getsubshard.yml
@@ -1,5 +1,5 @@
 ---
 - name: call RPC getsubshard
   # FIXME: should use the module `docker_container` instead
-  command: "{{ docker_exec_cmd }} './sharding-p2p-poc -loglevel=DEBUG -client getsubshard'"
+  command: "{{ docker_exec_cmd }} './sharding-p2p-poc -verbose -client getsubshard'"
   register: rpc_getsubshard_result

--- a/deployment/ansible/roles/common/tasks/cli_unsubshard.yml
+++ b/deployment/ansible/roles/common/tasks/cli_unsubshard.yml
@@ -1,4 +1,4 @@
 ---
 - name: call RPC unsubshard
   # FIXME: should use the module `docker_container` instead
-  command: "{{ docker_exec_cmd }} './sharding-p2p-poc -loglevel=DEBUG -client unsubshard {{ unsubshard_param['shard_id'] }}'"
+  command: "{{ docker_exec_cmd }} './sharding-p2p-poc -verbose -client unsubshard {{ unsubshard_param['shard_id'] }}'"

--- a/deployment/ansible/roles/common/tasks/run_docker.yml
+++ b/deployment/ansible/roles/common/tasks/run_docker.yml
@@ -13,7 +13,7 @@
       - "{{ item }}:10000" # listen port
       - "{{ 100 + item|int }}:13000" # RPC port
     command: [
-      "sh -c \"./sharding-p2p-poc -loglevel=DEBUG -ip=0.0.0.0 -seed={{ item }}\""
+      "sh -c \"./sharding-p2p-poc -verbose -ip=0.0.0.0 -seed={{ item }}\""
     ]
     env:
       JAEGER_AGENT_HOST: "{{hostvars[inventory_hostname]['groups']['log_collector'][0].split('@')[1]}}"

--- a/deployment/ansible/scripts/topology.py
+++ b/deployment/ansible/scripts/topology.py
@@ -83,7 +83,7 @@ def to_addpeer_commands(topology):
             "host": item["peer"].host,
             "command": (
                 f"docker exec -t {item['peer'].container_name} sh -c "
-                f"'./sharding-p2p-poc -loglevel=DEBUG "
+                f"'./sharding-p2p-poc -verbose "
                 f"-client addpeer {other.public_ip} {other.listen_port} {other.seed}'"
             )
         }
@@ -100,7 +100,7 @@ def to_subshard_commands(topology):
             "host": item["peer"].host,
             "command": (
                 f"docker exec -t {item['peer'].container_name} sh -c "
-                f"'./sharding-p2p-poc -loglevel=DEBUG "
+                f"'./sharding-p2p-poc -verbose "
                 f"-client subshard {item['shard_id']}'")
         }
         for item in topology
@@ -114,7 +114,7 @@ def to_broadcastcollation_commands(topology):
             "host": item["peer"].host,
             "command": (
                 f"docker exec -t {item['peer'].container_name} sh -c "
-                f"'./sharding-p2p-poc -loglevel=DEBUG "
+                f"'./sharding-p2p-poc -verbose "
                 f"-client broadcastcollation {item['shard_id']} {NUM_COLLATIONS} {COLLATION_SIZE} {FREQUENCY}'"
             )
         }

--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func main() {
 	)
 	doBootstrapping := flag.Bool("bootstrap", false, "whether to do bootstrapping or not")
 	bootnodesStr := flag.String("bootnodes", "", "multiaddresses of the bootnodes")
-	verbose := flag.Bool("verbose", false, "verbose output; if true, log level is set to DEBUG, ERROR otherwise")
+	verbose := flag.Bool("verbose", false, "verbose output, i.e., log level is set to DEBUG, otherwise it's set to ERROR")
 	isClient := flag.Bool("client", false, "is RPC client or server")
 	flag.Parse()
 

--- a/main.go
+++ b/main.go
@@ -70,13 +70,17 @@ func main() {
 	)
 	doBootstrapping := flag.Bool("bootstrap", false, "whether to do bootstrapping or not")
 	bootnodesStr := flag.String("bootnodes", "", "multiaddresses of the bootnodes")
-	logLevel := flag.String("loglevel", "INFO", "setting log level, e.g., DEBUG, WARNING, INFO, ERROR, CRITICAL")
+	verbose := flag.Bool("verbose", false, "verbose output; if true, log level is set to DEBUG, ERROR otherwise")
 	isClient := flag.Bool("client", false, "is RPC client or server")
 	flag.Parse()
 
 	rpcAddr := fmt.Sprintf("%v:%v", *rpcIP, *rpcPort)
 	notifierAddr := fmt.Sprintf("%v:%v", *rpcIP, *notifierPort)
-	logging.SetLogLevel("sharding-p2p", *logLevel)
+	if *verbose {
+		logging.SetLogLevel("sharding-p2p", "DEBUG")
+	} else {
+		logging.SetLogLevel("sharding-p2p", "ERROR")
+	}
 
 	cliArgs := flag.Args()
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -475,7 +475,6 @@ func (s *server) Bootstrap(
 }
 
 func runRPCServer(n *Node, addr string) {
-	// logging.SetLogLevel("sharding-p2p", "DEBUG")
 	// Start a new trace
 	ctx := context.Background()
 	ctx = logger.Start(ctx, "RPCServer")

--- a/test/utils.py
+++ b/test/utils.py
@@ -74,7 +74,7 @@ class Node:
             bootnodes_cmd = "-bootstrap -bootnodes={}".format(
                 ",".join(bootnodes),
             )
-        cmd = "docker run -d --name {} -p {}:10000 -p {}:13000 ethresearch/sharding-p2p:dev sh -c \"./sharding-p2p-poc -loglevel=DEBUG -ip=0.0.0.0 -seed={} {}\"".format(
+        cmd = "docker run -d --name {} -p {}:10000 -p {}:13000 ethresearch/sharding-p2p:dev sh -c \"./sharding-p2p-poc -verbose -ip=0.0.0.0 -seed={} {}\"".format(
             self.name,
             self.port,
             self.rpc_port,


### PR DESCRIPTION
### How was it fixed?
Replace `-loglevel=XXX` with `-verbose`
- With `-verbose` == `-loglevel=DEBUG `
- No `-verbose` == `-loglevel= ERROR `


#### Cute Animal Picture

![source: www.maxpixel.net](https://www.maxpixel.net/static/photo/2x/Dog-Blanket-Pug-Animal-Bed-Pet-Face-Funny-1210025.jpg)
