### PR TITLE
Fix #116

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sharding-p2p-poc
 
-[![Build Status](https://travis-ci.org/ethresearch/sharding-p2p-poc.svg?branch=master)](https://travis-ci.org/ethresearch/sharding-p2p-poc) [![](https://img.shields.io/badge/gitter-sharding--p2p--poc-ed1965.svg)](https://gitter.im/ethresearch/sharding-p2p-poc)
+[![Build Status](https://travis-ci.org/ethresearch/sharding-p2p-poc.svg?branch=master)](https://travis-ci.org/ethresearch/sharding-p2p-poc) [![](https://img.shields.io/badge/gitter-sharding--p2p--poc-ed1965.svg)](https://gitter.im/sharding-p2p-testing/Lobby)
 
 > This is the poc of ethereum sharding p2p layer with pubsub in libp2p, based on the idea from the [slide](
 https://docs.google.com/presentation/d/11a0jibNz0fyUnsWt9fa2MmghHANdHAAABa0TV7EieHs/edit?usp=sharing).

--- a/main.go
+++ b/main.go
@@ -251,7 +251,6 @@ func makeNode(
 		ctx,
 		libp2p.Identity(priv),
 		libp2p.ListenAddrStrings(listenAddrString),
-		libp2p.DisableRelay(),
 	)
 	if err != nil {
 		return nil, err

--- a/main_test.go
+++ b/main_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"regexp"
 	"testing"
 	"time"
 
@@ -62,11 +61,7 @@ func makeUnbootstrappedNode(t *testing.T, ctx context.Context, number int) *Node
 
 func connect(t *testing.T, ctx context.Context, a, b *Node) {
 	peerid := b.ID()
-	for _, addr := range b.Addrs() {
-		if match, _ := regexp.MatchString("^/ip4/.+/tcp/.+$", addr.String()); match {
-			a.Peerstore().AddAddr(peerid, addr, pstore.PermanentAddrTTL)
-		}
-	}
+	a.Peerstore().AddAddrs(peerid, b.Addrs(), pstore.PermanentAddrTTL)
 
 	if err := a.Connect(ctx, a.Peerstore().PeerInfo(peerid)); err != nil {
 		t.Errorf("Failed to connect to peer %v, err: %v", peerid, err)

--- a/main_test.go
+++ b/main_test.go
@@ -60,9 +60,9 @@ func makeUnbootstrappedNode(t *testing.T, ctx context.Context, number int) *Node
 }
 
 func connect(t *testing.T, ctx context.Context, a, b *Node) {
-	peerid, targetAddr, err := parseAddr(b.GetFullAddr())
+	peerid, targetAddr, err := parseAddr(b.GetIP4TCPAddr())
 	if err != nil {
-		t.Errorf("Failed to parse peer address: %s, err: %v", b.GetFullAddr(), err)
+		t.Errorf("Failed to parse peer address: %s, err: %v", b.GetIP4TCPAddr(), err)
 	}
 	a.Peerstore().AddAddr(peerid, targetAddr, pstore.PermanentAddrTTL)
 

--- a/node.go
+++ b/node.go
@@ -49,7 +49,10 @@ func NewNode(ctx context.Context, h host.Host, dht *kaddht.IpfsDHT, eventNotifie
 func (n *Node) GetIP4TCPAddr() string {
 	hostAddr, err := ma.NewMultiaddr(fmt.Sprintf("/ipfs/%s", n.ID().Pretty()))
 	if err != nil {
-		logger.Errorf("Failed to convert to multiaddr format, err: %v", err)
+		logger.Errorf(
+			"Failed to convert %s to multiaddr format, err: %v",
+			fmt.Sprintf("/ipfs/%s", n.ID().Pretty()),
+			err)
 	}
 	for _, addr := range n.Addrs() {
 		if match, _ := regexp.MatchString("^/ip4/.+/tcp/.+$", addr.String()); match {

--- a/node.go
+++ b/node.go
@@ -2,15 +2,12 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"regexp"
 
 	host "github.com/libp2p/go-libp2p-host"
 	kaddht "github.com/libp2p/go-libp2p-kad-dht"
 	peer "github.com/libp2p/go-libp2p-peer"
 	pstore "github.com/libp2p/go-libp2p-peerstore"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
-	ma "github.com/multiformats/go-multiaddr"
 )
 
 type Node struct {
@@ -44,23 +41,6 @@ func NewNode(ctx context.Context, h host.Host, dht *kaddht.IpfsDHT, eventNotifie
 	node.ShardManager = NewShardManager(ctx, node, pubsubService, eventNotifier, node.discovery, shardPrefTable)
 
 	return node
-}
-
-func (n *Node) GetIP4TCPAddr() string {
-	hostAddr, err := ma.NewMultiaddr(fmt.Sprintf("/ipfs/%s", n.ID().Pretty()))
-	if err != nil {
-		logger.Errorf(
-			"Failed to convert %s to multiaddr format, err: %v",
-			fmt.Sprintf("/ipfs/%s", n.ID().Pretty()),
-			err)
-	}
-	for _, addr := range n.Addrs() {
-		if match, _ := regexp.MatchString("^/ip4/.+/tcp/.+$", addr.String()); match {
-			fullAddr := addr.Encapsulate(hostAddr)
-			return fullAddr.String()
-		}
-	}
-	return ""
 }
 
 // TODO: should be changed to `Knows` and `HasConnections`

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -87,12 +87,6 @@ func (s *server) AddPeer(
 
 	logger.Debugf("rpcserver:AddPeer: ip=%v, port=%v, seed=%v", req.Ip, req.Port, req.Seed)
 	_, targetPID, err := makeKey(int(req.Seed))
-	mAddr := fmt.Sprintf(
-		"/ip4/%s/tcp/%d/ipfs/%s",
-		req.Ip,
-		req.Port,
-		targetPID.Pretty(),
-	)
 	if err != nil {
 		errMsg := fmt.Errorf("Failed to generate peer key/ID with seed: %v, err: %v", req.Seed, err)
 		logger.FinishWithErr(spanctx, errMsg)
@@ -100,9 +94,13 @@ func (s *server) AddPeer(
 		return nil, errMsg
 	}
 
-	peerid, targetAddr, err := parseAddr(mAddr)
+	peerid := targetPID
+	targetAddr, err := ma.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%d", req.Ip, req.Port))
 	if err != nil {
-		errMsg := fmt.Errorf("Failed to parse peer address: %s, err: %v", mAddr, err)
+		errMsg := fmt.Errorf(
+			"Failed to convert %s to multiaddr format, err: %v",
+			fmt.Sprintf("/ip4/%s/tcp/%d", req.Ip, req.Port),
+			err)
 		logger.FinishWithErr(spanctx, errMsg)
 		logger.Error(errMsg.Error())
 		return nil, errMsg


### PR DESCRIPTION
### How was it fixed?
Fix `GetFullAddr`. Replace it with `GetIP4TCPAddr` which returns the peer's ip4/tcp type multi-address so it can connect to it via tcp instead of Circuit Relay.
Or we can add both type(tcp and Circuit Relay) of multi-address to the address book.



#### Cute Animal Picture

![](https://www.publicdomainpictures.net/pictures/40000/velka/cute-dog-1364063120lnA.jpg)
