### PR TITLE
JSON-ize the output from Identify

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -154,7 +154,7 @@ func callIdentify(rpcAddr string) {
 	if err != nil {
 		logger.Fatalf("Failed to request identification from RPC server at %v, err: %v", rpcAddr, err)
 	}
-	fmt.Println(res.PeerID, res.GetMultiAddrs())
+	fmt.Println(marshalToJSONString(res))
 }
 
 func callRPCAddPeer(rpcAddr string, ipAddr string, port int, seed int) {

--- a/test/utils.py
+++ b/test/utils.py
@@ -119,6 +119,9 @@ class Node:
             return json.loads(out)
         return out
 
+    def identify(self):
+        return self.cli_safe("identify")
+
     def add_peer(self, node):
         self.cli_safe("addpeer {} {} {}".format(node.ip, node.port, node.seed))
 
@@ -185,11 +188,8 @@ class Node:
         return log
 
     def set_peer_id(self):
-        grep_res = self.wait_for_log('Node is listening', 0)
-        match = re.search(r'peerID=([a-zA-Z0-9]+) ', grep_res)
-        if match is None:
-            raise ValueError("failed to grep the peer_id from docker logs")
-        self.peer_id = match[1]
+        pinfo = self.identify()
+        self.peer_id = pinfo["peerID"]
 
     def get_log_time(self, pattern, k_th):
         log = self.wait_for_log(pattern, k_th)


### PR DESCRIPTION
### What was wrong?
The output from CLI `identify` is not in JSON format


### How was it fixed?
Marshal it to JSON before printing


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://scontent.ftpe7-4.fna.fbcdn.net/v/t1.0-9/48371470_1128505270677206_8813956259343499264_n.jpg?_nc_cat=1&_nc_ht=scontent.ftpe7-4.fna&oh=5926db55b6717ae53b34257c2bf0322f&oe=5CA3D7E4)
