### PR TITLE
Fix the out-dated API subshard

### DIFF
--- a/test/test_series.py
+++ b/test/test_series.py
@@ -134,10 +134,20 @@ def test_reproduce_bootstrapping_issue():
     all_nodes = bootnodes + nodes
     for node in all_nodes:
         node.subscribe_shard([1])
+
+    print("Sleeping for seconds...", end='')
+    time.sleep(3)
+    print("done")
+
     for node in all_nodes:
         peers = node.list_peer()
-        print(f"{node}: peers={peers}")
         topic_peers = node.list_topic_peer([])
+        print("{}: summary: len(peers)={}, len_per_topic={}".format(
+            node,
+            len(peers),
+            {key: len(value) for key, value in topic_peers.items()},
+        ))
+        print(f"{node}: peers={peers}")
         print(f"{node}: topic_peers={topic_peers}")
 
     kill_nodes(bootnodes + nodes)

--- a/test/utils.py
+++ b/test/utils.py
@@ -140,8 +140,8 @@ class Node:
     def list_topic_peer(self, topics=[]):
         return self.cli_safe(["listtopicpeer"] + topics)
 
-    def subscribe_shard(self, shard_ids):
-        self.cli_safe(["subshard"] + shard_ids)
+    def subscribe_shard(self, shard_ids, num_shard_peer_to_connect=0):
+        self.cli_safe(["subshard", num_shard_peer_to_connect] + shard_ids)
 
     def unsubscribe_shard(self, shard_ids):
         self.cli_safe(["unsubshard"] + shard_ids)


### PR DESCRIPTION
To align with the latest API in go

Besides, sleep 3 more seconds after `subshard` and print one more line in `test_reproduce_bootstrapping_issue`

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://scontent.ftpe8-1.fna.fbcdn.net/v/t1.0-9/48225605_1128505450677188_2013844705497841664_n.jpg?_nc_cat=1&_nc_ht=scontent.ftpe8-1.fna&oh=9e25fa72cb205ec2f350dcb641242bbe&oe=5C965685)
