### PR TITLE
[WIP] Fix/add update gomod

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,35 @@
+{
+  "author": "mhchia",
+  "bugs": {
+    "url": "https://github.com/ethresearch/sharding-p2p-poc"
+  },
+  "gx": {
+    "dvcsimport": "github.com/ethresearch/sharding-p2p-poc"
+  },
+  "gxDependencies": [
+    {
+      "author": "whyrusleeping",
+      "hash": "QmY51bqSM5XgxQZqsBrQcRkKTnCb8EKpJpR9K6Qax7Njco",
+      "name": "go-libp2p",
+      "version": "6.0.6"
+    },
+    {
+      "hash": "QmfBGjnPFqyJbPr8aSqEkQMfNkJUheD8mjxZ3jxkeYMFB3",
+      "name": "go-libp2p-kad-dht",
+      "version": "4.3.0"
+    },
+    {
+      "author": "whyrusleeping",
+      "hash": "QmXScvRbYh9X9okLuX9YMnz1HR4WgRTU2hocjBs15nmCNG",
+      "name": "go-libp2p-floodsub",
+      "version": "0.9.21"
+    }
+  ],
+  "gxVersion": "0.12.1",
+  "language": "go",
+  "license": "",
+  "name": "sharding-p2p-poc",
+  "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
+  "version": "0.0.0"
+}
+

--- a/package.json
+++ b/package.json
@@ -9,20 +9,20 @@
   "gxDependencies": [
     {
       "author": "whyrusleeping",
-      "hash": "QmY51bqSM5XgxQZqsBrQcRkKTnCb8EKpJpR9K6Qax7Njco",
+      "hash": "QmRBaUEQEeFWywfrZJ64QgsmvcqgLSK3VbvGMR2NM2Edpf",
       "name": "go-libp2p",
-      "version": "6.0.6"
+      "version": "6.0.28"
     },
     {
-      "hash": "QmfBGjnPFqyJbPr8aSqEkQMfNkJUheD8mjxZ3jxkeYMFB3",
+      "hash": "QmXbPygnUKAPMwseE5U3hQA7Thn59GVm7pQrhkFV63umT8",
       "name": "go-libp2p-kad-dht",
-      "version": "4.3.0"
+      "version": "4.4.17"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmXScvRbYh9X9okLuX9YMnz1HR4WgRTU2hocjBs15nmCNG",
-      "name": "go-libp2p-floodsub",
-      "version": "0.9.21"
+      "hash": "QmaqGyUhWLsJbVo1QAujSu13mxNjFJ98Kt2VWGSnShGE1Q",
+      "name": "go-libp2p-pubsub",
+      "version": "0.11.9"
     }
   ],
   "gxVersion": "0.12.1",

--- a/scripts/update-gomod.py
+++ b/scripts/update-gomod.py
@@ -21,25 +21,87 @@ if version_str < least_go_version_str:
 
 
 GOPATH = os.getenv('GOPATH')
+TMP_GIT_REPO_PATH = "/tmp/gx-git-repos"
 
 
-def get_gx_path(gx_hash, repo_name):
-    return "{}/src/gx/ipfs/{}/{}".format(GOPATH, gx_hash, repo_name)
-
-
-def get_github_repo_path(github_repo):
-    return "{}/src/{}".format(GOPATH, github_repo)
-
-
-def download_and_update_deps(root_repo_path):
-    # subprocess.run(
-    #     "cd GO111MODULE=off go get -d -u {}".format(github_repo),
-    #     shell=True,
-    # )
+class DownloadFailure(Exception):
     pass
 
 
+class FetchCommitFailure(Exception):
+    pass
+
+
+def make_gx_path(gx_hash, repo_name):
+    return "{}/src/gx/ipfs/{}/{}".format(GOPATH, gx_hash, repo_name)
+
+
+def make_github_repo_path(github_repo):
+    return "{}/src/{}".format(GOPATH, github_repo)
+
+
+def make_git_cmd(path, command):
+    """Helper function to do git operations avoiding changing directories
+    """
+    return "git --git-dir={}/.git {}".format(path, command)
+
+
+def download_git_repo(git_repo):
+    repo_path = "{}/{}".format(TMP_GIT_REPO_PATH, git_repo)
+    if not os.path.exists(TMP_GIT_REPO_PATH):
+        try:
+            os.mkdir(TMP_GIT_REPO_PATH)
+        except FileExistsError:
+            pass
+
+    if not os.path.exists(repo_path):
+        git_url = "https://{}".format(git_repo)
+        res = subprocess.run("git clone {} {}".format(git_url, repo_path), shell=True)
+    else:
+        res = subprocess.run(
+            make_git_cmd(repo_path, "pull origin master"),
+            shell=True,
+        )
+    if res.returncode != 0:
+        raise DownloadFailure("failed to download/update the git repo: repo={}, res={}".format(
+            git_repo,
+            res,
+        ))
+
+
+def get_commit_from_git_repo(git_repo, gx_hash):
+    git_repo_path = make_github_repo_path(git_repo)
+    res = subprocess.run(
+        "{} | xargs {} | tail -n1".format(
+            make_git_cmd(git_repo_path, "rev-list --all"),
+            make_git_cmd(git_repo_path, "grep {}".format(gx_hash)),
+        ),
+        shell=True,
+        stdout=subprocess.PIPE,
+    )
+    if res.returncode != 0:
+        raise FetchCommitFailure("failed to fetch the commit: gx_hash={}, repo={}".format(
+            gx_hash,
+            git_repo,
+        ))
+    # success
+    try:
+        result = res.stdout.decode()
+        module_commit = result.split(':')[0]
+    except IndexError:
+        raise FetchCommitFailure(
+            "fail to parse the commit: gx_hash={}, repo={}, result={}".format(
+                gx_hash,
+                git_repo,
+                result,
+            )
+        )
+    return module_commit
+
+
 def update_repo_to_go_mod(root_repo_path):
+    """Go through the dependencies
+    """
     visited_repos = set()
     queue = list()
     queue.append(('', root_repo_path))
@@ -57,7 +119,7 @@ def update_repo_to_go_mod(root_repo_path):
             for dep_info in deps:
                 dep_name = dep_info['name']
                 dep_gx_hash = dep_info['hash']
-                dep_gx_path = get_gx_path(dep_gx_hash, dep_name)
+                dep_gx_path = make_gx_path(dep_gx_hash, dep_name)
                 queue.append((dep_gx_hash, dep_gx_path))
         # exclude the root repo
         if repo_path == root_repo_path:
@@ -67,28 +129,12 @@ def update_repo_to_go_mod(root_repo_path):
         # 1. need `github_repo` + `gx_hash`
         # 2. `git --git-dir=`github_repo`/.git rev-list|xargs git grep `gx_hash`, and find the first commit containing this hash
         # 3. go get `github_repo`@`commit`
-        github_repo = package_info['gx']['dvcsimport']
-        github_repo_path = get_github_repo_path(github_repo)
-        print("handling repo: gx_hash={}, repo_path={}, github_path={}".format(repo_gx_hash, repo_path, github_repo_path))
-        res = subprocess.run(
-            "git --git-dir={0}/.git rev-list --all | xargs git --git-dir={0}/.git grep {1} | tail -n1".format(
-                github_repo_path,
-                repo_gx_hash,
-            ),
-            shell=True,
-            stdout=subprocess.PIPE,
-        )
-        if res.returncode == 0:
-            # success
-            try:
-                result = res.stdout.decode()
-                module_commit = result.split(':')[0]
-            except IndexError:
-                raise Exception("fail to parse the commit record: {}".format(module_commit))
-            res = subprocess.run(
-                "GO111MODULE=on go get {}@{}".format(github_repo, module_commit),
-                shell=True,
-            )
+        git_repo = package_info['gx']['dvcsimport']
+        git_repo_path = make_github_repo_path(git_repo)
+        print("handling repo: gx_hash={}, repo_path={}, github_path={}".format(repo_gx_hash, repo_path, git_repo_path))
+        download_git_repo(git_repo)
+        commit = get_commit_from_git_repo(git_repo, repo_gx_hash)
+        print("!@# commit={}".format(commit))
 
 
 if __name__ == "__main__":

--- a/scripts/update-gomod.py
+++ b/scripts/update-gomod.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+
+import json
+import os
+import re
+import subprocess
+
+
+least_go_version_str = '1.11'
+# ensure go version >= `least_go_version_str`
+res_go_version = subprocess.run(["go", "version"], stdout=subprocess.PIPE)
+if res_go_version.returncode != 0:
+    raise Exception("failed to run `go version`")
+res_go_version_str = res_go_version.stdout.decode()
+ret = re.search(r"go\sversion\sgo([0-9]+\.[0-9]+)", res_go_version_str)
+if ret is None:
+    raise Exception("failed to parse the version from `go version`")
+version_str = ret.groups(0)[0]
+if version_str < least_go_version_str:
+    raise Exception("go version should be >= {}".format(least_go_version_str))
+
+
+GOPATH = os.getenv('GOPATH')
+
+
+def get_gx_path(gx_hash, repo_name):
+    return "{}/src/gx/ipfs/{}/{}".format(GOPATH, gx_hash, repo_name)
+
+
+def get_github_repo_path(github_repo):
+    return "{}/src/{}".format(GOPATH, github_repo)
+
+
+def download_and_update_deps(root_repo_path):
+    # subprocess.run(
+    #     "cd GO111MODULE=off go get -d -u {}".format(github_repo),
+    #     shell=True,
+    # )
+    pass
+
+
+def update_repo_to_go_mod(root_repo_path):
+    visited_repos = set()
+    queue = list()
+    queue.append(('', root_repo_path))
+    while len(queue) != 0:
+        repo_gx_hash, repo_path = queue.pop()
+        if repo_path in visited_repos:
+            continue
+        visited_repos.add(repo_path)
+        json_file_path = "{}/package.json".format(repo_path)
+        with open(json_file_path, 'r') as f_read:
+            package_info = json.load(f_read)
+        # add the deps
+        if 'gxDependencies' in package_info:
+            deps = package_info['gxDependencies']
+            for dep_info in deps:
+                dep_name = dep_info['name']
+                dep_gx_hash = dep_info['hash']
+                dep_gx_path = get_gx_path(dep_gx_hash, dep_name)
+                queue.append((dep_gx_hash, dep_gx_path))
+        # exclude the root repo
+        if repo_path == root_repo_path:
+            continue
+
+        # TODO: handle go get here!
+        # 1. need `github_repo` + `gx_hash`
+        # 2. `git --git-dir=`github_repo`/.git rev-list|xargs git grep `gx_hash`, and find the first commit containing this hash
+        # 3. go get `github_repo`@`commit`
+        github_repo = package_info['gx']['dvcsimport']
+        github_repo_path = get_github_repo_path(github_repo)
+        print("handling repo: gx_hash={}, repo_path={}, github_path={}".format(repo_gx_hash, repo_path, github_repo_path))
+        res = subprocess.run(
+            "git --git-dir={0}/.git rev-list --all | xargs git --git-dir={0}/.git grep {1} | tail -n1".format(
+                github_repo_path,
+                repo_gx_hash,
+            ),
+            shell=True,
+            stdout=subprocess.PIPE,
+        )
+        if res.returncode == 0:
+            # success
+            try:
+                result = res.stdout.decode()
+                module_commit = result.split(':')[0]
+            except IndexError:
+                raise Exception("fail to parse the commit record: {}".format(module_commit))
+            res = subprocess.run(
+                "GO111MODULE=on go get {}@{}".format(github_repo, module_commit),
+                shell=True,
+            )
+
+
+if __name__ == "__main__":
+    current_path = os.getcwd()
+    update_repo_to_go_mod(current_path)

--- a/scripts/update-gomod.py
+++ b/scripts/update-gomod.py
@@ -79,12 +79,14 @@ def download_git_repo(git_repo):
             pass
     if not os.path.exists(make_git_path(repo_path)):
         git_url = "https://{}".format(git_repo)
-        res = subprocess.run("git clone {} {}".format(git_url, repo_path), shell=True, encoding='utf-8')
+        res = subprocess.run(
+            "git clone {} {}".format(git_url, repo_path),
+            shell=True,
+        )
     else:
         res = subprocess.run(
             make_git_cmd(repo_path, "pull origin master"),
             shell=True,
-            encoding='utf-8',
         )
     if res.returncode != 0:
         raise DownloadFailure("failed to download/update the git repo: repo={}, res={}".format(
@@ -269,5 +271,16 @@ def do_download():
     download_repos(git_repo_list)
 
 
+supported_modes = {"update": do_update, "download": do_download}
+
+
 if __name__ == "__main__":
-    do_update()
+    if len(sys.argv) <= 1:
+        raise ValueError("Need the argument `mode`")
+    mode = sys.argv[1]
+    if mode not in supported_modes:
+        raise ValueError("Wrong mode={}. Supported: {}".format(
+            mode,
+            ", ".join([i for i in supported_modes.keys()])
+        ))
+    supported_modes[mode]()

--- a/scripts/update-gomod.py
+++ b/scripts/update-gomod.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import json
+import logging
 import os
 import re
 import subprocess
@@ -8,10 +9,10 @@ import subprocess
 
 least_go_version_str = '1.11'
 # ensure go version >= `least_go_version_str`
-res_go_version = subprocess.run(["go", "version"], stdout=subprocess.PIPE)
+res_go_version = subprocess.run(["go", "version"], stdout=subprocess.PIPE, encoding='utf-8')
 if res_go_version.returncode != 0:
     raise Exception("failed to run `go version`")
-res_go_version_str = res_go_version.stdout.decode()
+res_go_version_str = res_go_version.stdout
 ret = re.search(r"go\sversion\sgo([0-9]+\.[0-9]+)", res_go_version_str)
 if ret is None:
     raise Exception("failed to parse the version from `go version`")
@@ -24,43 +25,70 @@ GOPATH = os.getenv('GOPATH')
 TMP_GIT_REPO_PATH = "/tmp/gx-git-repos"
 
 
+logger = logging.getLogger("update-gomod")
+
+
 class DownloadFailure(Exception):
     pass
 
 
-class FetchCommitFailure(Exception):
+class GetCommitFailure(Exception):
     pass
 
 
-def make_gx_path(gx_hash, repo_name):
-    return "{}/src/gx/ipfs/{}/{}".format(GOPATH, gx_hash, repo_name)
+class GetVersionFailure(Exception):
+    pass
 
 
-def make_github_repo_path(github_repo):
-    return "{}/src/{}".format(GOPATH, github_repo)
+class GxPath:
+    gx_hash = None
+    repo_name = None
+
+    def __init__(self, gx_hash, repo_name):
+        self.gx_hash = gx_hash
+        self.repo_name = repo_name
+
+    @property
+    def gx_path(self):
+        return "{}/src/gx/ipfs/{}/{}".format(GOPATH, self.gx_hash, self.repo_name)
+
+    @classmethod
+    def from_gx_path(cls, gx_path):
+        path_list = gx_path.split('/')
+        if len(path_list) < 6:
+            raise ValueError("malform gx_path={}".format(gx_path))
+        return cls(path_list[4], path_list[5])
+
+
+def make_git_repo_path(git_repo):
+    return "{}/{}".format(TMP_GIT_REPO_PATH, git_repo)
+
+
+def make_git_path(git_repo_path):
+    return "{}/.git".format(git_repo_path)
 
 
 def make_git_cmd(path, command):
     """Helper function to do git operations avoiding changing directories
     """
-    return "git --git-dir={}/.git {}".format(path, command)
+    return "git --git-dir={} {}".format(make_git_path(path), command)
 
 
 def download_git_repo(git_repo):
-    repo_path = "{}/{}".format(TMP_GIT_REPO_PATH, git_repo)
+    repo_path = make_git_repo_path(git_repo)
     if not os.path.exists(TMP_GIT_REPO_PATH):
         try:
             os.mkdir(TMP_GIT_REPO_PATH)
         except FileExistsError:
             pass
-
-    if not os.path.exists(repo_path):
+    if not os.path.exists(make_git_path(repo_path)):
         git_url = "https://{}".format(git_repo)
-        res = subprocess.run("git clone {} {}".format(git_url, repo_path), shell=True)
+        res = subprocess.run("git clone {} {}".format(git_url, repo_path), shell=True, encoding='utf-8')
     else:
         res = subprocess.run(
             make_git_cmd(repo_path, "pull origin master"),
             shell=True,
+            encoding='utf-8',
         )
     if res.returncode != 0:
         raise DownloadFailure("failed to download/update the git repo: repo={}, res={}".format(
@@ -69,8 +97,29 @@ def download_git_repo(git_repo):
         ))
 
 
-def get_commit_from_git_repo(git_repo, gx_hash):
-    git_repo_path = make_github_repo_path(git_repo)
+def download_repos(git_repos):
+    for git_repo in git_repos:
+        download_git_repo(git_repo)
+
+
+def is_version_in_repo(git_repo, sem_ver):
+    git_repo_path = make_git_repo_path(git_repo)
+    res = subprocess.run(
+        "{}".format(
+            make_git_cmd(git_repo_path, "tag")
+        ),
+        shell=True,
+        encoding='utf-8',
+        stdout=subprocess.PIPE,
+    )
+    if res.returncode != 0:
+        raise GetVersionFailure("failed to access the repo: git_repo={}".format(git_repo))
+    version_list = res.stdout.split('\n')
+    return sem_ver in version_list
+
+
+def get_commit_from_repo(git_repo, gx_hash):
+    git_repo_path = make_git_repo_path(git_repo)
     res = subprocess.run(
         "{} | xargs {} | tail -n1".format(
             make_git_cmd(git_repo_path, "rev-list --all"),
@@ -78,40 +127,59 @@ def get_commit_from_git_repo(git_repo, gx_hash):
         ),
         shell=True,
         stdout=subprocess.PIPE,
+        encoding="utf-8",
     )
     if res.returncode != 0:
-        raise FetchCommitFailure("failed to fetch the commit: gx_hash={}, repo={}".format(
+        raise GetCommitFailure("failed to fetch the commit: gx_hash={}, repo={}".format(
             gx_hash,
             git_repo,
         ))
     # success
     try:
-        result = res.stdout.decode()
+        result = res.stdout
         module_commit = result.split(':')[0]
     except IndexError:
-        raise FetchCommitFailure(
+        raise GetCommitFailure(
             "fail to parse the commit: gx_hash={}, repo={}, result={}".format(
                 gx_hash,
                 git_repo,
                 result,
             )
         )
+    # check if `module_commit` is a commit hash, e.g. 5a13bddfa3a06705681ade8e1d4ea85374b6b12e
+    try:
+        int(module_commit, 16)
+    except ValueError:
+        return None
+    if len(module_commit) != 40:
+        return None
     return module_commit
 
 
-def update_repo_to_go_mod(root_repo_path):
+def _remove_url_prefix(url):
+    return re.sub(r"\w+://", "", url)
+
+
+def _dvcsimport_to_git_repo(dvcsimport_path):
+    # Assume `devcsimport_path` is in the format of `site/user/repo/package`.
+    # Therefore, we only need to get rid of the `package`
+    layered_paths = dvcsimport_path.split('/')
+    return "/".join(layered_paths[:3])
+
+
+def get_repo_deps(root_repo_path):
     """Go through the dependencies
     """
-    visited_repos = set()
+    visited_repos = {}  # repo_gx_path -> git_repo
     queue = list()
-    queue.append(('', root_repo_path))
+
+    queue.append(root_repo_path)
     while len(queue) != 0:
-        repo_gx_hash, repo_path = queue.pop()
+        repo_path = queue.pop()
         if repo_path in visited_repos:
             continue
-        visited_repos.add(repo_path)
-        json_file_path = "{}/package.json".format(repo_path)
-        with open(json_file_path, 'r') as f_read:
+        package_file_path = "{}/package.json".format(repo_path)
+        with open(package_file_path, 'r') as f_read:
             package_info = json.load(f_read)
         # add the deps
         if 'gxDependencies' in package_info:
@@ -119,24 +187,76 @@ def update_repo_to_go_mod(root_repo_path):
             for dep_info in deps:
                 dep_name = dep_info['name']
                 dep_gx_hash = dep_info['hash']
-                dep_gx_path = make_gx_path(dep_gx_hash, dep_name)
-                queue.append((dep_gx_hash, dep_gx_path))
-        # exclude the root repo
-        if repo_path == root_repo_path:
-            continue
+                dep_gx_path = GxPath(dep_gx_hash, dep_name).gx_path
+                queue.append(dep_gx_path)
+        try:
+            git_repo = _dvcsimport_to_git_repo(_remove_url_prefix(package_info["bugs"]["url"]))
+        except KeyError:
+            git_repo = _dvcsimport_to_git_repo(package_info['gx']['dvcsimport'])
+        version = None
+        if "version" in package_info:
+            version = package_info["version"]
+        visited_repos[repo_path] = (git_repo, version)
+    # exclude the root repo itself
+    del visited_repos[root_repo_path]
+    return visited_repos
 
-        # TODO: handle go get here!
-        # 1. need `github_repo` + `gx_hash`
-        # 2. `git --git-dir=`github_repo`/.git rev-list|xargs git grep `gx_hash`, and find the first commit containing this hash
-        # 3. go get `github_repo`@`commit`
-        git_repo = package_info['gx']['dvcsimport']
-        git_repo_path = make_github_repo_path(git_repo)
-        print("handling repo: gx_hash={}, repo_path={}, github_path={}".format(repo_gx_hash, repo_path, git_repo_path))
-        download_git_repo(git_repo)
-        commit = get_commit_from_git_repo(git_repo, repo_gx_hash)
-        print("!@# commit={}".format(commit))
+
+def parse_version_from_repo_gx_hash(git_repo, raw_version, repo_gx_hash):
+    """dep to version or commit?
+    """
+    # TODO: add checks to ensure gx repos are downloaded(with `gx install`?)
+    # try to find the version in the downloaded git repo
+    commit = version = None
+    sem_ver = "v{}".format(raw_version)
+    if is_version_in_repo(git_repo, sem_ver):
+        version = sem_ver
+    else:
+        # try to find the commit in the downloaded git repo
+        # XXX: will fail if the git repo does not contain information of gx_hash
+        #      the usual case is, the repo is not maintained by IPFS teams
+        commit = get_commit_from_repo(git_repo, repo_gx_hash)
+    return version, commit
+
+
+def update_repo_to_go_mod(git_repo, version=None, commit=None):
+    if version is not None:
+        print("updating git_repo={} with version={} ...".format(git_repo, version), end="")
+        version_indicator = version
+    elif commit is not None:
+        print("updating git_repo={} with commit={} ...".format(git_repo, commit), end="")
+        version_indicator = commit
+    else:
+        raise ValueError("failed to update {}: version and commit are both None".format(git_repo))
+    subprocess.run(
+        "GO111MODULE=on go get {}@{}".format(git_repo, version_indicator),
+        shell=True,
+        stdout=subprocess.PIPE,
+    )
+    print("finished")
+
+
+def update_repos(map_repos):
+    for repo_gx_path, repo_version in map_repos.items():
+        git_repo, raw_version = repo_version
+        gx_obj = GxPath.from_gx_path(repo_gx_path)
+        gx_hash = gx_obj.gx_hash
+        version, commit = parse_version_from_repo_gx_hash(git_repo, raw_version, gx_hash)
+        try:
+            update_repo_to_go_mod(git_repo, version, commit)
+        except ValueError:
+            # FIXME: ignore the failed updates for now
+            logger.debug("failed to update the repo %s", git_repo)
 
 
 if __name__ == "__main__":
     current_path = os.getcwd()
-    update_repo_to_go_mod(current_path)
+    import sys
+    deps_map = get_repo_deps(current_path)
+    # filter out non-github deps
+    github_deps = {
+        repo_gx_path: repo_version
+        for repo_gx_path, repo_version in deps_map.items()
+        if "github.com" in repo_version[0]
+    }
+    update_repos(github_deps)


### PR DESCRIPTION
### What was wrong?
https://github.com/ethresearch/sharding-p2p-poc/issues/130


### How was it fixed?
- Add `package.json` back, to specify the dependencies on gx.
- Add the python script `scripts/update-gomod.py`, which parses the dependency on gx, turns gx-hash to git commits, and updates them to `go.mod` and `go.sum` using `go get`.

There are two modes in this script: `download`, and `update`.
- `download`: download and update all dependencies of the current repo according to the gx dependency file `package.json`, to the path `/tmp/gx-git-repos`. 
- `update`: parse the dependencies information described by `package.json` with BFS and get the gx versions in the format in the below for each dependency. Then, search for the _git commit_ or _release version_ with the gx information, in the downloaded repos which are fetched in mode `download`. Last, use those _git commit_ or _release version_, we can do `GO111MODULE=on go get {repo}@{commit or version}` to update the versions to `go.mod`
```json
{
    "hash": "QmaqGyUhWLsJbVo1QAujSu13mxNjFJ98Kt2VWGSnShGE1Q",
    "name": "go-libp2p-pubsub",
    "version": "0.11.9",
}
```

#### Example
```bash
$ cd {path/to/sharding-p2p-poc}
$ python scripts/update-gomod.py download  # Download the git repos of all dependencies(including the indirect ones)
$ python scripts/update-gomod.py update
$ GO111MODULE=on go build
```

#### Current issues
- [x] Haven't verified whether `go get` truly update the dependency to `go.mod` or not
- [x] Seems the version specified in gx(`package.json`) is not necessarily equaled to the one in `git tag`

#### Reference
- gx-gomod: https://github.com/whyrusleeping/gx/issues/200
  - Introduce gomod and proposed a proxy solution for resolution of gx hashes. E.g. version string can be like `v2.7.3-gx-ipfs-Qmb3GBFCHMuzmi9EpH3pxpYBiviyc3tEPyDQHxZJQJSxj9` in https://github.com/whyrusleeping/gx/issues/200#issuecomment-413218625
- Gx hash mapped to git commit?: https://github.com/whyrusleeping/gx/issues/190
  - Seems currently it is not supported
- Reconsidering gx: https://github.com/ipfs/go-ipfs/issues/5850
  - discussion about gomod v.s. gx
- Make GX pleasant to use: https://github.com/whyrusleeping/gx/issues/179#issuecomment-408243162
  - I haven't fully understand the proposed changes, great discussion tho
- gxed organization: https://github.com/gxed
  - The gx'ed repos are put here.
 
#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://scontent.ftpe3-1.fna.fbcdn.net/v/t1.0-9/48260372_1128505457343854_2397782578095456256_n.jpg?_nc_cat=104&_nc_ht=scontent.ftpe3-1.fna&oh=07013c059c99ec9cc01e4921e7cbe7a9&oe=5C8CE2CE)
