### PR TITLE
Testing: Gather data with percentage

### DIFF
--- a/test/utils.py
+++ b/test/utils.py
@@ -239,13 +239,8 @@ def make_local_nodes(low, top, bootnodes=None):
 
     time.sleep(5)
 
-    threads = []
     for node in nodes:
-        t = threading.Thread(target=node.set_peer_id, args=())
-        t.start()
-        threads.append(t)
-    for t in threads:
-        t.join()
+        node.set_peer_id()
     return nodes
 
 


### PR DESCRIPTION
### What was wrong?
Previously the `test_time_broadcasting_data_single_shard` only returns the time when the last node in the barbell receives the broadcasted data. What we prefer is to know how much time it takes to broadcast the data to `X%` nodes.

### How was it fixed?
Gather the time data into a list, sort the list, and fetch the time of the `num_nodes * X%`th node

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://scontent.ftpe8-2.fna.fbcdn.net/v/t1.0-9/48393666_1135769396617460_7176665810725765120_o.jpg?_nc_cat=103&_nc_ht=scontent.ftpe8-2.fna&oh=90de2f8d56b89417367863aafe76e2b8&oe=5C974C8F)
