### PR TITLE
Fix #146: README typo and more notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ For more information, please check out the [document](https://github.com/ethrese
 - `go` with `1.11.x` or above is installed and properly configured on your machine.
     - `$GOPATH` variable has been [specified](https://github.com/golang/go/wiki/GOPATH).
     - `$GOPATH/bin/` is part of your `$PATH`.
-- If you modify `*.proto` files, you will also need `protoc` to compile them to `*.pb.go`
-    - e.g., [Install protoc on mac](https://medium.com/@erika_dike/installing-the-protobuf-compiler-on-a-mac-a0d397af46b8)
+- If you modify `*.proto` files, you will also need `protoc` to compile them to `*.pb.go`.
+    - e.g., [Install protoc on mac](https://medium.com/@erika_dike/installing-the-protobuf-compiler-on-a-mac-a0d397af46b8).
 
 ### Build
 
@@ -60,7 +60,7 @@ Usage of ./sharding-p2p-poc:
 
 **Note**
 - `-bootstrap` controls whether to spin up a bootstrap routine, which periodically queries its peers for new peers. There will be no effect if you feed `-bootnodes` without specifying the flag `-bootstrap`.
-- `-client` indicates we are running a client of sharding-p2p-poc. If not specifying the flag it will be run as the server by default. Details can be found in the [section](#command-line-interface)
+- `-client` indicates we are running a client of sharding-p2p-poc. If not specifying the flag it will be run as the server by default. Details can be found in this [section](#command-line-interface).
 
 ### Example
 
@@ -81,7 +81,7 @@ To give commands to the node you have spun up, you can run the command in this f
 $ ./sharding-p2p-poc -client -rpcport={rpcport} {method_name} {params}
 ```
 
-The flag `-rpcport` is important since it is used to specify which node you are going to communicate with. If you don't specify it, the current default `rpcport` is `13000`
+The flag `-rpcport` is important since it is used to specify which node you are going to communicate with. If you don't specify it, the current default `rpcport` is `13000`.
 
 Since they are still subject to changes, please check out the [documentations](https://notes.ethereum.org/s/HJdvvyTmm) for further reference to the RPC methods. You can also check out the examples [here](https://github.com/ethresearch/sharding-p2p-poc/tree/master/cli-example).
 

--- a/README.md
+++ b/README.md
@@ -42,17 +42,25 @@ Usage of ./sharding-p2p-poc:
     	whether to do bootstrapping or not
   -client
     	is RPC client or server
+  -ip string
+    	ip listened by the process for incoming connections (default "127.0.0.1")
+  -notifierport int
+    	notifier port listened by the event rpc server
   -port int
     	port listened by the node for incoming connections (default 10000)
+  -rpcip string
+    	ip listened by the RPC server (default "127.0.0.1")
   -rpcport int
-    	rpc port listened by the rpc server (default 13000)
+    	RPC port listened by the RPC server (default 13000)
   -seed int
     	set random seed for id generation
   -verbose
-        set the log level to DEBUG, i.e., print all messages
+    	verbose output, i.e., log level is set to DEBUG, otherwise it's set to ERROR
 ```
 
-**Note**: `-bootstrap` controls whether to spin up a bootstrap routine, which periodically queries its peers for new peers. There will be no effect if you feed `-bootnodes` without specifying the flag `-bootstrap`.
+**Note**
+- `-bootstrap` controls whether to spin up a bootstrap routine, which periodically queries its peers for new peers. There will be no effect if you feed `-bootnodes` without specifying the flag `-bootstrap`.
+- `-client` indicates we are running a client of sharding-p2p-poc. If not specifying the flag it will be run as the server by default. Details can be found in the [section](#command-line-interface)
 
 ### Example
 
@@ -61,7 +69,7 @@ Usage of ./sharding-p2p-poc:
 ```bash
 $ ./sharding-p2p-poc -seed=1 -port=10001 -rpcport=13001 -bootstrap -bootnodes=/ip4/127.0.0.1/tcp/5566/ipfs/QmS5QmciTXXnCUCyxud5eWFenUMAmvAWSDa1c7dvdXRMZ7,/ip4/127.0.0.1/tcp/10001/ipfs/QmexAnfpHrhMmAC5UNQVS8iBuUUgDrMbMY17Cck2gKrqeX
 ```
-This command spins up a node with seed `0`, listening to new connections at port `10001`, listening to RPC requests at port `13001`, turning on bootstrapping mode with the flag`-bootstrap`, with the bootstrapping nodes `/ip4/127.0.0.1/tcp/5566/ipfs/QmS5QmciTXXnCUCyxud5eWFenUMAmvAWSDa1c7dvdXRMZ7` and `/ip4/127.0.0.1/tcp/10001/ipfs/QmexAnfpHrhMmAC5UNQVS8iBuUUgDrMbMY17Cck2gKrqeX`.
+This command spins up a node with seed `1`, listening to new connections at port `10001`, listening to RPC requests at port `13001`, turning on bootstrapping mode with the flag`-bootstrap`, with the bootstrapping nodes `/ip4/127.0.0.1/tcp/5566/ipfs/QmS5QmciTXXnCUCyxud5eWFenUMAmvAWSDa1c7dvdXRMZ7` and `/ip4/127.0.0.1/tcp/10001/ipfs/QmexAnfpHrhMmAC5UNQVS8iBuUUgDrMbMY17Cck2gKrqeX`.
 
 **Note**: `/ip4/127.0.0.1/tcp/10001/ipfs/QmexAnfpHrhMmAC5UNQVS8iBuUUgDrMbMY17Cck2gKrqeX` is the format of ipfs address, which is in the form of `/ip4/{ip}/tcp/{port}/{peerID}`.
 

--- a/test/README.md
+++ b/test/README.md
@@ -1,57 +1,57 @@
-# Testing Methodology 
+# Testing Methodology
 
 ## Overview
 The network is segmented into X number of shards. Every ~10 minutes, validators are randomly assigned to a shard, so the stress point is observing and testing the ability of validators to subscribe to new topics and send/receive messages pertaining to this new topic in an adequate amount of time.
 
-Please reference [this document](https://notes.ethereum.org/s/ByYhlJBs7) for further details pertaining to the test plan. 
+Please reference [this document](https://notes.ethereum.org/s/ByYhlJBs7) for further details pertaining to the test plan.
 
 ## Test Utility
 We will perform tests using the [Whiteblock](www.whiteblock.io) testing platform. The following functionalities would likely be most relevant to this particular test series:
 
-* Number of nodes: <100 (more if necessary)  
-* Automated provisioning of nodes  
-* Behaviors, parameters, commands, and actions can be automated or assigned to individual nodes and also the network as a whole.  
-* Bandwidth: 1G (standard, up to 10G if necessary) can be configured and assigned to each individual node.  
-* VLAN: Each node can be configured within its own VLAN and assigned a unique IP address, allowing for the emulation of realistic network conditions which accurately mimic real-world conditions.  
-* Latency: Up to 1 second of network latency can be applied to each node’s individual link.  
-* Data aggregation and visualization  
+* Number of nodes: <100 (more if necessary)
+* Automated provisioning of nodes
+* Behaviors, parameters, commands, and actions can be automated or assigned to individual nodes and also the network as a whole.
+* Bandwidth: 1G (standard, up to 10G if necessary) can be configured and assigned to each individual node.
+* VLAN: Each node can be configured within its own VLAN and assigned a unique IP address, allowing for the emulation of realistic network conditions which accurately mimic real-world conditions.
+* Latency: Up to 1 second of network latency can be applied to each node’s individual link.
+* Data aggregation and visualization
 
 ## Test Scenarios
 
-* Observe and measure performance under the presence of various network conditions.  
-  * Latency between nodes:  
-    * What is the maximum amount of network latency each individual node can tolerate before performance begins to degrade?  
-    * What are the security implications of high degrees of latency?  
-    * Are there any other unforeseen issues which may arise from network conditions for which we can’t accommodate via traditional code?  
-  * Latency between shards.  
-  * Intermittent blackout conditions  
-  * High degrees of packet loss  
-  * Bandwidth constraints (various bandwidth sizes)  
-* Introduce new nodes to network:  
-  * Add/remove nodes at random.  
-  * Add/remove nodes at set intervals.  
-  * Introduce a high volume of nodes simultaneously.  
-* Partition tolerance  
-  * Prevent segments of nodes from communicating with one another.  
-* Measure the performance of sending/receiving messages within set time periods and repeat for N epoches.  
-* Observe process of nodes joining and leaving shards  
-  * Subscribing to shards  
-  * Connecting to other nodes within shard  
-  * Synchronize collations and ShardPreferenceTable  
-  * Unsubscribing from shards  
+* Observe and measure performance under the presence of various network conditions.
+  * Latency between nodes:
+    * What is the maximum amount of network latency each individual node can tolerate before performance begins to degrade?
+    * What are the security implications of high degrees of latency?
+    * Are there any other unforeseen issues which may arise from network conditions for which we can’t accommodate via traditional code?
+  * Latency between shards.
+  * Intermittent blackout conditions
+  * High degrees of packet loss
+  * Bandwidth constraints (various bandwidth sizes)
+* Introduce new nodes to network:
+  * Add/remove nodes at random.
+  * Add/remove nodes at set intervals.
+  * Introduce a high volume of nodes simultaneously.
+* Partition tolerance
+  * Prevent segments of nodes from communicating with one another.
+* Measure the performance of sending/receiving messages within set time periods and repeat for N epoches.
+* Observe process of nodes joining and leaving shards
+  * Subscribing to shards
+  * Connecting to other nodes within shard
+  * Synchronize collations and ShardPreferenceTable
+  * Unsubscribing from shards
 
-## Need to Define  
+## Need to Define
 
-* Configuration specifications for relevant test cases to create templates which allow for quicker test automation.  
-* Code which should be tested.  
-* Preliminary testing methodology should be established based on everyone's input.  
-  * We can make adjustments to this methodology based on the results of each test case.  
-  * It's generally best (in my experience) to create a high-level overview which provides a more granular definition of the first three test cases and then make adjustments to each subsequent test series based on the results of those three.  
+* Configuration specifications for relevant test cases to create templates which allow for quicker test automation.
+* Code which should be tested.
+* Preliminary testing methodology should be established based on everyone's input.
+  * We can make adjustments to this methodology based on the results of each test case.
+  * It's generally best (in my experience) to create a high-level overview which provides a more granular definition of the first three test cases and then make adjustments to each subsequent test series based on the results of those three.
 
-## Other Notes  
+## Other Notes
 
-* This document acts as a high-level overview to communicate potential test scenarios based on our initial assumptions of the existing codebase. It is meant to act as a starting point to guide the development of a preliminary test series.  
-* Although tests will be run locally within our lab, access to the test network can be granted to appropriate third-parties for the sake of due diligence, validation, or other purposes as deemed necessary.  
-* Network statistics and performance data dashboard can be assigned a public IP to allow for public access.  
-* Raw and formatted data will be shared within appropriate repos.  
-* Please voice any suggestions, comments, or concerns in this thread and feel free to contact me on Gitter.  
+* This document acts as a high-level overview to communicate potential test scenarios based on our initial assumptions of the existing codebase. It is meant to act as a starting point to guide the development of a preliminary test series.
+* Although tests will be run locally within our lab, access to the test network can be granted to appropriate third-parties for the sake of due diligence, validation, or other purposes as deemed necessary.
+* Network statistics and performance data dashboard can be assigned a public IP to allow for public access.
+* Raw and formatted data will be shared within appropriate repos.
+* Please voice any suggestions, comments, or concerns in this thread and feel free to contact me on Gitter.


### PR DESCRIPTION
### What was wrong?
#146 , thanks @araskachoi  for pointing the issues


### How was it fixed?
- Fix the typo in the example
- Add notes about `-client`
- Remove trailing spaces in test/README.md



#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://scontent.ftpe3-1.fna.fbcdn.net/v/t1.0-9/48397353_1931997006853729_836823155845627904_n.jpg?_nc_cat=110&_nc_ht=scontent.ftpe3-1.fna&oh=2ba98b0284f989947663f60a4229f021&oe=5CBFBCDD)
